### PR TITLE
Fix #7 detect json by languageId

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -146,7 +146,7 @@ export class AzureRMTools {
             let foundDeploymentTemplate = false;
 
             if (document.getText() &&
-                lowerCasedDocumentUri.endsWith(".json") &&
+                document.languageId.toLowerCase() === 'json' &&
                 !lowerCasedDocumentUri.startsWith("git-index:/")) {
 
                 // If the documentUri is not in our dictionary of deployment templates, then we


### PR DESCRIPTION
Fix #7 

If a new file hasn't been saved yet, it won't have a ".json" file extension. The extension should detect json file type by the languageId property of the document instead of file extension.