### PR TITLE
Make JSON outline show only for ARM templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
                 {
                     "id": "json-outline",
                     "name": "JSON Outline",
-                    "when": "resourceLangId == json"
+                    "when": "showArmJsonView"
                 }
             ]
         }

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -34,7 +34,7 @@ import { SurveySettings } from "./SurveySettings";
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(new Reporter(context));
-    context.subscriptions.push(new AzureRMTools());
+    context.subscriptions.push(new AzureRMTools(context));
 }
 
 // this method is called when your extension is deactivated
@@ -70,12 +70,12 @@ export class AzureRMTools {
         }
     });
 
-    constructor() {
+    constructor(context: vscode.ExtensionContext) {
         this.loadConfiguration();
 
-        const jsonOutline = new JsonOutlineProvider();
-        vscode.window.registerTreeDataProvider("json-outline", jsonOutline);
-        vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => jsonOutline.goToDefinition(range));
+        const jsonOutline = new JsonOutlineProvider(context);
+        context.subscriptions.push(vscode.window.registerTreeDataProvider("json-outline", jsonOutline));
+        context.subscriptions.push(vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => jsonOutline.goToDefinition(range)));
         
         this.log({
             eventName: "Extension Activated"

--- a/src/DeploymentTemplate.ts
+++ b/src/DeploymentTemplate.ts
@@ -111,7 +111,7 @@ export class DeploymentTemplate {
     }
 
     public hasValidSchemaUri(): boolean {
-        return DeploymentTemplate.isValidSchemaUri(this.schemaUri);
+        return Utilities.isValidSchemaUri(this.schemaUri);
     }
 
     public get errors(): Promise<language.Issue[]> {
@@ -454,10 +454,6 @@ export class DeploymentTemplate {
         }
 
         return result;
-    }
-
-    public static isValidSchemaUri(schema: string): boolean {
-        return schema ? schema.match(/https?:\/\/schema.management.azure.com\/schemas\/.*\/deploymentTemplate.json/) !== null : false;
     }
 }
 

--- a/src/Treeview.ts
+++ b/src/Treeview.ts
@@ -8,41 +8,43 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
     private text: string;
     private editor: vscode.TextEditor;
 
-    public readonly onDidChangeTreeDataEmitter: vscode.EventEmitter <string | null> =
+    public readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<string | null> =
         new vscode.EventEmitter<string | null>();
     public readonly onDidChangeTreeData: vscode.Event<string | null> = this.onDidChangeTreeDataEmitter.event;
 
     constructor(private context?: vscode.ExtensionContext) {
-        
+
         vscode.window.onDidChangeActiveTextEditor((ev) => {
-            
+
             this.refresh();
         });
         vscode.workspace.onDidChangeTextDocument((ev) => this.refresh(ev));
         vscode.workspace.onDidOpenTextDocument((ev) => this.refresh());
     }
-    
-     public refresh(event?: vscode.TextDocumentChangeEvent) {
+
+    public refresh(event?: vscode.TextDocumentChangeEvent) {
 
         this.parseTree(vscode.window.activeTextEditor.document);
         this.onDidChangeTreeDataEmitter.fire(void 0);
-    } 
+    }
 
     public getChildren(element?: string): string[] {
 
         // check if there is a visible text editor
-        if (vscode.window.visibleTextEditors.length > 0){
-            if (vscode.window.activeTextEditor.document.languageId === 'json'){
+        if (vscode.window.visibleTextEditors.length > 0) {
+            if (vscode.window.activeTextEditor.document.languageId === 'json') {
 
-                if(!this.tree){
+                if (!this.tree) {
                     this.refresh();
                 }
 
                 let result = [];
-                if(!element){
-                    for(var i=0, il=this.tree.value.properties.length; i < il; i++){
-                        let item = this.getElementInfo(this.tree.value.properties[i]);
-                        result.push(item);
+                if (!element) {
+                    if (!!this.tree.value) {
+                        for (let i = 0, il = this.tree.value.properties.length; i < il; i++) {
+                            let item = this.getElementInfo(this.tree.value.properties[i]);
+                            result.push(item);
+                        }
                     }
                 }
                 else {
@@ -51,17 +53,17 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
 
                     // Value is an object and is collapsible
                     if (elementInfo.current.value.type === "ObjectValue" && elementInfo.current.collapsible) {
-                   
-                            for(var i=0, il=valueNode.properties.length; i < il; i++){
-                                let item = this.getElementInfo(valueNode.properties[i], elementInfo);
-                                result.push(item);
-                            
+
+                        for (var i = 0, il = valueNode.properties.length; i < il; i++) {
+                            let item = this.getElementInfo(valueNode.properties[i], elementInfo);
+                            result.push(item);
+
                         }
                     }
                     else if (elementInfo.current.value.type === "ArrayValue" && elementInfo.current.collapsible) {
                         // Array with Object
-                        if (valueNode.elements[0].constructor.name === "ObjectValue"){
-                            for(var i=0, il=valueNode.length; i < il; i++){
+                        if (valueNode.elements[0].constructor.name === "ObjectValue") {
+                            for (var i = 0, il = valueNode.length; i < il; i++) {
                                 let item = this.getElementInfo(valueNode.elements[i], elementInfo);
                                 result.push(item);
                             }
@@ -79,11 +81,11 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
         const start = vscode.window.activeTextEditor.document.positionAt(elementInfo.current.key.start);
         const end = vscode.window.activeTextEditor.document.positionAt(elementInfo.current.value.end);
 
-        let treeItem: vscode.TreeItem  = {
+        let treeItem: vscode.TreeItem = {
             label: this.getLabel(elementInfo),
             collapsibleState: elementInfo.current.collapsible ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
             iconPath: this.getIconPath(elementInfo),
-            command : {
+            command: {
                 arguments: [new vscode.Range(start, end)],
                 command: "extension.treeview.goto",
                 title: "",
@@ -94,13 +96,13 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
 
     public goToDefinition(range: vscode.Range) {
         const editor: vscode.TextEditor = vscode.window.activeTextEditor;
-    
-            // Center the method in the document
-            editor.revealRange(range, vscode.TextEditorRevealType.Default);
-            // Select the method name
-            editor.selection = new vscode.Selection(range.start, range.end);
-            // Swap the focus to the editor
-            vscode.window.showTextDocument(editor.document, editor.viewColumn, false);
+
+        // Center the method in the document
+        editor.revealRange(range, vscode.TextEditorRevealType.Default);
+        // Select the method name
+        editor.selection = new vscode.Selection(range.start, range.end);
+        // Swap the focus to the editor
+        vscode.window.showTextDocument(editor.document, editor.viewColumn, false);
     }
 
     private parseTree(document?: vscode.TextDocument): void {
@@ -114,37 +116,37 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
     private getLabel(elementInfo): string {
 
         const keyNode = this.tree.getValueAtCharacterIndex(elementInfo.current.key.start);
-        
+
         // Key is an object (e.g. a resource object)
-        if(elementInfo.current.key.type === "ObjectValue"){
+        if (elementInfo.current.key.type === "ObjectValue") {
             let foundName = false;
             // Object contains no elements
-            if(keyNode.properties.length === 0){
+            if (keyNode.properties.length === 0) {
                 return "{}";
             }
             else {
-                
+
                 // Object contains elements, look for name element
-                for(var i=0, l=keyNode.properties.length; i < l; i++){
+                for (var i = 0, l = keyNode.properties.length; i < l; i++) {
                     let props = keyNode.properties[i];
                     // If name element is found
-                    if (props.name._value.toUpperCase() === "name".toUpperCase()){
+                    if (props.name._value.toUpperCase() === "name".toUpperCase()) {
                         foundName = true;
                         return props.value._value;
                     }
                 }
                 // Object contains elements, but not a name element
-                if (!foundName){
+                if (!foundName) {
                     return "{...}";
                 }
             }
-            
+
         }
         // Value is an Array
-        else if (elementInfo.current.value.type === "ArrayValue"){
+        else if (elementInfo.current.value.type === "ArrayValue") {
             return keyNode._value;
         }
-        else if (elementInfo.current.value.type === "ObjectValue"){
+        else if (elementInfo.current.value.type === "ObjectValue") {
             return keyNode._value;
         }
         else {
@@ -153,27 +155,27 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
         }
     }
 
-    private getElementInfo (childElement, elementInfo?: IElementInfo){
+    private getElementInfo(childElement, elementInfo?: IElementInfo) {
 
         let collapsible = false;
         let keyIsObject = false;
 
         // Is childElement an Object
-        if (childElement.constructor.name === "ObjectValue"){
+        if (childElement.constructor.name === "ObjectValue") {
             keyIsObject = true;
-            if (childElement.properties.length > 0){
+            if (childElement.properties.length > 0) {
                 collapsible = true;
             }
         }
         // Is value an Array and does it have elements
-        else if (childElement.value.constructor.name === "ArrayValue" && childElement.value.elements.length > 0){
+        else if (childElement.value.constructor.name === "ArrayValue" && childElement.value.elements.length > 0) {
             // Is the first element in the Array an Object
-            if (childElement.value.elements[0].constructor.name === "ObjectValue"){
+            if (childElement.value.elements[0].constructor.name === "ObjectValue") {
                 collapsible = true;
             }
         }
         // Is value an Object and does it have elements
-        else if (childElement.value.constructor.name === "ObjectValue" && childElement.value.properties.length > 0){
+        else if (childElement.value.constructor.name === "ObjectValue" && childElement.value.properties.length > 0) {
             collapsible = true;
         }
 
@@ -206,32 +208,32 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
             },
             root: {
                 key: {
-                    start:childElement.startIndex
+                    start: childElement.startIndex
                 }
             }
         }
 
         // Key of the node is an Object
-        if(!keyIsObject){
-            result.current.key.type=childElement.name.constructor.name;
-            result.current.value.start=childElement.value.startIndex;
-            result.current.value.end=childElement.value.span.afterEndIndex;
-            result.current.value.type=childElement.value.constructor.name;
+        if (!keyIsObject) {
+            result.current.key.type = childElement.name.constructor.name;
+            result.current.value.start = childElement.value.startIndex;
+            result.current.value.end = childElement.value.span.afterEndIndex;
+            result.current.value.type = childElement.value.constructor.name;
         }
         else {
-            result.current.key.type= childElement.constructor.name;
-            result.current.value.start= childElement.startIndex;
-            result.current.value.end= childElement.span.afterEndIndex;
-            result.current.value.type= childElement.constructor.name;
+            result.current.key.type = childElement.constructor.name;
+            result.current.value.start = childElement.startIndex;
+            result.current.value.end = childElement.span.afterEndIndex;
+            result.current.value.type = childElement.constructor.name;
         }
 
         // Not a root element
-        if (elementInfo){
-            result.parent.key.start= elementInfo.current.key.start;
-            result.parent.key.end= elementInfo.current.key.end;
-            result.parent.key.type= elementInfo.current.key.type;
-            result.parent.value.start= elementInfo.current.value.start;
-            result.parent.value.end= elementInfo.current.value.end;
+        if (elementInfo) {
+            result.parent.key.start = elementInfo.current.key.start;
+            result.parent.key.end = elementInfo.current.key.end;
+            result.parent.key.type = elementInfo.current.key.type;
+            result.parent.value.start = elementInfo.current.value.start;
+            result.parent.value.end = elementInfo.current.value.end;
             result.root.key.start = elementInfo.root.key.start;
             result.current.level = elementInfo.current.level + 1;
         }
@@ -242,59 +244,59 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
         return JSON.stringify(result);
     }
 
-    private getIconPath(elementInfo: IElementInfo): string{
+    private getIconPath(elementInfo: IElementInfo): string {
 
-            let icon;
-            const keyNode = this.tree.getValueAtCharacterIndex(elementInfo.current.key.start);
+        let icon;
+        const keyNode = this.tree.getValueAtCharacterIndex(elementInfo.current.key.start);
 
-            // Is current element a root element?
-            if (elementInfo.current.level === 1){
-                if (keyNode._value.toUpperCase() === "$schema".toUpperCase()){icon = "label.svg"};
-                if (keyNode._value.toUpperCase() === "version".toUpperCase()){icon = "label.svg"};
-                if (keyNode._value.toUpperCase() === "contentVersion".toUpperCase()){icon = "label.svg"};
-                if (keyNode._value.toUpperCase() === "handler".toUpperCase()){icon = "label.svg"};
-                if (keyNode._value.toUpperCase() === "parameters".toUpperCase()){icon = "parameters.svg"};
-                if (keyNode._value.toUpperCase() === "variables".toUpperCase()){icon = "variables.svg"};
-                if (keyNode._value.toUpperCase() === "resources".toUpperCase()){icon = "resources.svg"};
-                if (keyNode._value.toUpperCase() === "outputs".toUpperCase()){icon = "outputs.svg"};
-                
-            }
-            // Is current element a element of a root element?
-            else if (elementInfo.current.level === 2){
-                // Get root value
-                const rootNode = this.tree.getValueAtCharacterIndex(elementInfo.root.key.start);
+        // Is current element a root element?
+        if (elementInfo.current.level === 1) {
+            if (keyNode._value.toUpperCase() === "$schema".toUpperCase()) { icon = "label.svg" };
+            if (keyNode._value.toUpperCase() === "version".toUpperCase()) { icon = "label.svg" };
+            if (keyNode._value.toUpperCase() === "contentVersion".toUpperCase()) { icon = "label.svg" };
+            if (keyNode._value.toUpperCase() === "handler".toUpperCase()) { icon = "label.svg" };
+            if (keyNode._value.toUpperCase() === "parameters".toUpperCase()) { icon = "parameters.svg" };
+            if (keyNode._value.toUpperCase() === "variables".toUpperCase()) { icon = "variables.svg" };
+            if (keyNode._value.toUpperCase() === "resources".toUpperCase()) { icon = "resources.svg" };
+            if (keyNode._value.toUpperCase() === "outputs".toUpperCase()) { icon = "outputs.svg" };
 
-                if (rootNode._value.toUpperCase() === "parameters".toUpperCase()){icon = "parameters.svg"};
-                if (rootNode._value.toUpperCase() === "variables".toUpperCase()){icon = "variables.svg"};
-                if (rootNode._value.toUpperCase() === "outputs".toUpperCase()){icon = "outputs.svg"};
-            }
+        }
+        // Is current element a element of a root element?
+        else if (elementInfo.current.level === 2) {
+            // Get root value
+            const rootNode = this.tree.getValueAtCharacterIndex(elementInfo.root.key.start);
 
-            // If resourceType element is found on resource objects set to specific resourceType Icon or else a a default resource icon 
-            if (elementInfo.current.level > 1 && elementInfo.current.key.type === "ObjectValue"){
-                const rootNode = this.tree.getValueAtCharacterIndex(elementInfo.root.key.start);
+            if (rootNode._value.toUpperCase() === "parameters".toUpperCase()) { icon = "parameters.svg" };
+            if (rootNode._value.toUpperCase() === "variables".toUpperCase()) { icon = "variables.svg" };
+            if (rootNode._value.toUpperCase() === "outputs".toUpperCase()) { icon = "outputs.svg" };
+        }
 
-                if (rootNode._value.toUpperCase() === "resources".toUpperCase()){
-                    
-                    for (var i = 0, il = keyNode.properties.length; i < il; i++){
-                        if (keyNode.properties[i].name._value.toUpperCase() === "type".toUpperCase()){
-                            let resourceType = keyNode.properties[i].value._value.toUpperCase();
-                                icon = "resources.svg";
-                                resourceType === "Microsoft.Compute/virtualMachines".toUpperCase() ? icon = "virtualmachines.svg" : undefined;
-                                resourceType === "Microsoft.Storage/storageAccounts".toUpperCase() ? icon = "storageaccounts.svg" : undefined;
-                                resourceType === "Microsoft.Network/virtualNetworks".toUpperCase() ? icon = "virtualnetworks.svg" : undefined;
-                                resourceType === "Microsoft.Compute/virtualMachines/extensions".toUpperCase() ? icon = "extensions.svg" : undefined;
-                                resourceType === "Microsoft.Network/networkSecurityGroups".toUpperCase() ? icon = "nsg.svg" : undefined;
-                                resourceType === "Microsoft.Network/networkInterfaces".toUpperCase() ? icon = "nic.svg" : undefined;
-                                resourceType === "Microsoft.Network/publicIPAddresses".toUpperCase() ? icon = "publicip.svg" : undefined;
-                        }
+        // If resourceType element is found on resource objects set to specific resourceType Icon or else a a default resource icon 
+        if (elementInfo.current.level > 1 && elementInfo.current.key.type === "ObjectValue") {
+            const rootNode = this.tree.getValueAtCharacterIndex(elementInfo.root.key.start);
+
+            if (rootNode._value.toUpperCase() === "resources".toUpperCase()) {
+
+                for (var i = 0, il = keyNode.properties.length; i < il; i++) {
+                    if (keyNode.properties[i].name._value.toUpperCase() === "type".toUpperCase()) {
+                        let resourceType = keyNode.properties[i].value._value.toUpperCase();
+                        icon = "resources.svg";
+                        resourceType === "Microsoft.Compute/virtualMachines".toUpperCase() ? icon = "virtualmachines.svg" : undefined;
+                        resourceType === "Microsoft.Storage/storageAccounts".toUpperCase() ? icon = "storageaccounts.svg" : undefined;
+                        resourceType === "Microsoft.Network/virtualNetworks".toUpperCase() ? icon = "virtualnetworks.svg" : undefined;
+                        resourceType === "Microsoft.Compute/virtualMachines/extensions".toUpperCase() ? icon = "extensions.svg" : undefined;
+                        resourceType === "Microsoft.Network/networkSecurityGroups".toUpperCase() ? icon = "nsg.svg" : undefined;
+                        resourceType === "Microsoft.Network/networkInterfaces".toUpperCase() ? icon = "nic.svg" : undefined;
+                        resourceType === "Microsoft.Network/publicIPAddresses".toUpperCase() ? icon = "publicip.svg" : undefined;
                     }
                 }
             }
-            if (icon){
-               return (__dirname + '/../../icons/' + icon);
-            }
+        }
+        if (icon) {
+            return (__dirname + '/../../icons/' + icon);
+        }
         return;
-    } 
+    }
 }
 
 export interface IElementInfo {

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -154,6 +154,10 @@ export function getCombinedText(values: { toString(): string }[]): string {
     return result;
 }
 
+export function isValidSchemaUri(schema: string): boolean {
+    return schema ? schema.match(/https?:\/\/schema.management.azure.com\/schemas\/.*\/deploymentTemplate.json/) !== null : false;
+}
+
 /**
  * An interface for an object that iterates through a sequence of values.
  */

--- a/test/DeploymentTemplate.test.ts
+++ b/test/DeploymentTemplate.test.ts
@@ -885,44 +885,6 @@ suite("DeploymentTemplate", () => {
             assert.deepStrictEqual(list.spans, [new language.Span(18, 5)]);
         });
     });
-
-    suite("isValidSchemaUri(string)", () => {
-        test("with null", () => {
-            assert.equal(false, DeploymentTemplate.isValidSchemaUri(null));
-        });
-
-        test("with undefined", () => {
-            assert.equal(false, DeploymentTemplate.isValidSchemaUri(undefined));
-        });
-
-        test("with 'hello world'", () => {
-            assert.equal(false, DeploymentTemplate.isValidSchemaUri("hello world"));
-        });
-
-        test("with 'www.bing.com'", () => {
-            assert.equal(false, DeploymentTemplate.isValidSchemaUri("www.bing.com"));
-        });
-
-        test("with 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'", () => {
-            assert.equal(true, DeploymentTemplate.isValidSchemaUri("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"));
-        });
-
-        test("with 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json'", () => {
-            assert.equal(true, DeploymentTemplate.isValidSchemaUri("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json"));
-        });
-
-        test("with 'http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json'", () => {
-            assert.equal(true, DeploymentTemplate.isValidSchemaUri("http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json"));
-        });
-
-        test("with 'http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'", () => {
-            assert.equal(true, DeploymentTemplate.isValidSchemaUri("http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"));
-        });
-
-        test("with 'https://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#'", () => {
-            assert.equal(true, DeploymentTemplate.isValidSchemaUri("https://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#"));
-        });
-    });
 });
 
 suite("ReferenceInVariableDefinitionJSONVisitor", () => {

--- a/test/Utilities.test.ts
+++ b/test/Utilities.test.ts
@@ -274,4 +274,42 @@ suite("Utilities", () => {
             assert.deepStrictEqual(Utilities.escapeAndQuote("\very"), `"\\very"`);
         });
     });
+
+    suite("isValidSchemaUri(string)", () => {
+        test("with null", () => {
+            assert.equal(false, Utilities.isValidSchemaUri(null));
+        });
+
+        test("with undefined", () => {
+            assert.equal(false, Utilities.isValidSchemaUri(undefined));
+        });
+
+        test("with 'hello world'", () => {
+            assert.equal(false, Utilities.isValidSchemaUri("hello world"));
+        });
+
+        test("with 'www.bing.com'", () => {
+            assert.equal(false, Utilities.isValidSchemaUri("www.bing.com"));
+        });
+
+        test("with 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'", () => {
+            assert.equal(true, Utilities.isValidSchemaUri("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"));
+        });
+
+        test("with 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json'", () => {
+            assert.equal(true, Utilities.isValidSchemaUri("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json"));
+        });
+
+        test("with 'http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json'", () => {
+            assert.equal(true, Utilities.isValidSchemaUri("http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json"));
+        });
+
+        test("with 'http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'", () => {
+            assert.equal(true, Utilities.isValidSchemaUri("http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"));
+        });
+
+        test("with 'https://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#'", () => {
+            assert.equal(true, Utilities.isValidSchemaUri("https://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#"));
+        });
+    });    
 });


### PR DESCRIPTION
Fix #17 - Now the extension detects for ARM template schema in a JSON, only when an ARM template is detected, the TreeView will be visible.

Fix #18 - Now the TreeView will be visible for newly created but not yet saved to disk ARM templates.