### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -76,7 +76,7 @@ export class AzureRMTools {
         const jsonOutline = new JsonOutlineProvider(context);
         context.subscriptions.push(vscode.window.registerTreeDataProvider("json-outline", jsonOutline));
         context.subscriptions.push(vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => jsonOutline.goToDefinition(range)));
-        
+
         this.log({
             eventName: "Extension Activated"
         });
@@ -134,13 +134,13 @@ export class AzureRMTools {
 
     private updateDeploymentTemplate(document: vscode.TextDocument): void {
         if (document) {
-            const documentUri: string = document.uri.toString();
-            const lowerCasedDocumentUri: string = documentUri.toLowerCase();
             let foundDeploymentTemplate = false;
 
             if (document.getText() &&
                 document.languageId.toLowerCase() === 'json' &&
-                !lowerCasedDocumentUri.startsWith("git-index:/")) {
+                document.uri.scheme === 'file') {
+
+                const documentUri: string = document.uri.toString();
 
                 // If the documentUri is not in our dictionary of deployment templates, then we
                 // know that this document was opened (as opposed to changed/updated).


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](http://aka.ms/vsls) adding support for "guests" to receive remote language services for ARM templates, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

The extension was already rejecting the `git-index:` scheme, so instead of also rejecting the `vsls:` scheme, I just changed it to look for `file:` based documents, which is likely a better behavior long term (since there can be over virtual file system providers). 