### PR TITLE
Use displayName tag and shorten name labels

### DIFF
--- a/src/JSON.ts
+++ b/src/JSON.ts
@@ -498,6 +498,11 @@ export abstract class Value {
     }
 
     public abstract accept(visitor: Visitor): void;
+
+    /**
+     * A user-friendly string that represents this value, suitable for display in a label, etc.
+     */
+    public abstract toFriendlyString(): string;
 }
 
 /**
@@ -571,6 +576,10 @@ export class ObjectValue extends Value {
     public accept(visitor: Visitor): void {
         visitor.visitObjectValue(this);
     }
+
+    public toFriendlyString(): string {
+        return "(object)";
+    }
 }
 
 /**
@@ -597,6 +606,10 @@ export class Property extends Value {
 
     public accept(visitor: Visitor): void {
         visitor.visitProperty(this);
+    }
+
+    public toFriendlyString(): string {
+        return "(property)";
     }
 }
 
@@ -632,6 +645,10 @@ export class ArrayValue extends Value {
     public accept(visitor: Visitor): void {
         visitor.visitArrayValue(this);
     }
+
+    public toFriendlyString(): string {
+        return "(array)";
+    }
 }
 
 /**
@@ -656,6 +673,10 @@ export class BooleanValue extends Value {
     public accept(visitor: Visitor): void {
         visitor.visitBooleanValue(this);
     }
+
+    public toFriendlyString(): string {
+        return this.toString();
+    }
 }
 
 /**
@@ -677,6 +698,10 @@ export class StringValue extends Value {
     public accept(visitor: Visitor): void {
         visitor.visitStringValue(this);
     }
+
+    public toFriendlyString(): string {
+        return this.toString();
+    }
 }
 
 /**
@@ -694,6 +719,10 @@ export class NumberValue extends Value {
     public accept(visitor: Visitor): void {
         visitor.visitNumberValue(this);
     }
+
+    public toFriendlyString(): string {
+        return this.toString();
+    }
 }
 
 /**
@@ -710,6 +739,10 @@ export class NullValue extends Value {
 
     public accept(visitor: Visitor): void {
         visitor.visitNullValue(this);
+    }
+
+    public toFriendlyString(): string {
+        return this.toString();
     }
 }
 

--- a/src/Treeview.ts
+++ b/src/Treeview.ts
@@ -56,8 +56,8 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
                     }
                 }
                 else {
-                    let elementInfo = JSON.parse(element);
-                    assert(!!elementInfo.tree, "elementInfo.tree not defined");
+                    let elementInfo = <IElementInfo>JSON.parse(element);
+                    assert(!!elementInfo.current, "elementInfo.current not defined");
                     let valueNode = this.tree.getValueAtCharacterIndex(elementInfo.current.value.start);
 
                     // Value is an object and is collapsible

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -10,10 +10,39 @@ import * as Json from "../src/JSON";
 import * as path from "path";
 
 import { ext } from "../src/extensionVariables"
-import { JsonOutlineProvider, IElementInfo } from "../src/Treeview";
+import { JsonOutlineProvider, IElementInfo, shortenTreeLabel } from "../src/Treeview";
 import { Span } from "../src/Language";
 
 suite("TreeView", async (): Promise<void> => {
+    suite("shortenTreeLabel", async (): Promise<void> => {
+        test("shortenTreeLabel", () => {
+            function testShorten(label: string, expected: string) {
+                let shortenedLabel = shortenTreeLabel(label);
+                assert.equal(shortenedLabel, expected);
+            }
+
+            testShorten(undefined, undefined);
+            testShorten(null, null);
+            testShorten("", "");
+            testShorten("a", "a");
+            testShorten("[]", "[]");
+            testShorten("[parameter('a')]", "[parameter('a')]");
+            testShorten("[parameterss('a')]", "[parameterss('a')]");
+
+            // params/vars
+            testShorten("[parameters('a')]", "<a>");
+            testShorten("[variables('a')]", "<a>");
+            testShorten("[(variables('a')+variables('abc'))]", "(<a>+<abc>)");
+
+            // concat
+            testShorten("[concat(a)]", "a");
+            testShorten("[concat(variables('a'),'b',variables('abc'))]", "<a>,'b',<abc>");
+
+            // nested concat
+            testShorten("[concat(concat(a))]", "a");
+        });
+    });
+
     suite("JsonOutlineProvider", async (): Promise<void> => {
         let provider: JsonOutlineProvider;
 
@@ -542,7 +571,7 @@ suite("TreeView", async (): Promise<void> => {
                         icon: "resources.svg",
                         children: [
                             {
-                                label: "[variables('virtualNetworkName')]",
+                                label: "<virtualNetworkName>",
                                 collapsibleState: 1,
                                 icon: "virtualnetworks.svg",
                                 children: [
@@ -581,7 +610,7 @@ suite("TreeView", async (): Promise<void> => {
                                                 collapsibleState: 1,
                                                 children: [
                                                     {
-                                                        label: "[variables('subnetName')]",
+                                                        label: "<subnetName>",
                                                         collapsibleState: 1,
                                                         children: [
                                                             {
@@ -611,7 +640,7 @@ suite("TreeView", async (): Promise<void> => {
                                                         ]
                                                     },
                                                     {
-                                                        label: "[variables('appGwSubnetName')]",
+                                                        label: "<appGwSubnetName>",
                                                         collapsibleState: 1,
                                                         children: [
                                                             {

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -161,7 +161,7 @@ suite("TreeView", async (): Promise<void> => {
                         label: "resources",
                         children: [
                             {
-                                label: "SwarmNSG",
+                                label: "NSG - Swarm",
                                 children: [
                                     {
                                         label: "apiVersion: 2017-03-01",

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -145,7 +145,7 @@ suite("TreeView", async (): Promise<void> => {
                             "location": "[resourceGroup().location]",
                             "tags": {
                                 "any": "who there",
-                                "displayName": "NSG - Swarm"
+                                "displayName": "Swarm Display Name"
                             }
                         }
                     ]
@@ -161,7 +161,7 @@ suite("TreeView", async (): Promise<void> => {
                         label: "resources",
                         children: [
                             {
-                                label: "NSG - Swarm",
+                                label: "Swarm Display Name",
                                 children: [
                                     {
                                         label: "apiVersion: 2017-03-01",
@@ -182,7 +182,7 @@ suite("TreeView", async (): Promise<void> => {
                                                 label: "any: who there",
                                             },
                                             {
-                                                label: "displayName: NSG - Swarm",
+                                                label: "displayName: Swarm Display Name",
                                             }
                                         ]
                                     }
@@ -637,7 +637,7 @@ suite("TreeView", async (): Promise<void> => {
                                 ]
                             },
                             {
-                                label: "SwarmNSG",
+                                label: "Swarm Display Name",
                                 collapsibleState: 1,
                                 icon: "nsg.svg",
                                 children: [
@@ -666,7 +666,7 @@ suite("TreeView", async (): Promise<void> => {
                                                 collapsibleState: 0
                                             },
                                             {
-                                                label: "displayName: NSG - Swarm",
+                                                label: "displayName: Swarm Display Name",
                                                 collapsibleState: 0
                                             }
                                         ]
@@ -985,7 +985,7 @@ const templateAllParamDefaultTypes: string = `
                         "location": "[resourceGroup().location]",
                         "tags": {
                             "any": "who there",
-                            "displayName": "NSG - Swarm"
+                            "displayName": "Swarm Display Name"
                         },
                         "properties": {
                             "securityRules": [

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -68,7 +68,7 @@ suite("TreeView", async (): Promise<void> => {
 
         test("getChildren: Top level: all default param types", async () => {
 
-            await testChildren(template, [
+            await testChildren(templateAllParamDefaultTypes, [
                 {
                     label: "$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     collapsibleState: 0,
@@ -79,8 +79,7 @@ suite("TreeView", async (): Promise<void> => {
                     icon: "label.svg"
                 }, {
                     label: "a: undefined", // Until https://github.com/Microsoft/vscode-azurearmtools/issues is fixed
-                    collapsibleState: 0,
-                    icon: undefined
+                    collapsibleState: 0
                 }, {
                     label: "parameters",
                     collapsibleState: 1,
@@ -97,9 +96,87 @@ suite("TreeView", async (): Promise<void> => {
             ]);
         });
 
+        test("getLabel: displayName tag", async () => {
+
+            await testTree(`
+                {
+                    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "apiVersion": "2017-03-01",
+                            "type": "Microsoft.Network/networkSecurityGroups",
+                            "name": "SwarmNSG",
+                            "location": "[resourceGroup().location]",
+                            "tags": {
+                                "any": "who there",
+                                "displayName": "NSG - Swarm"
+                            }
+                        }
+                    ]
+                }`,
+                [
+                    {
+                        label: "$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                        collapsibleState: 0,
+                        icon: "label.svg"
+                    },
+                    {
+                        label: "contentVersion: 1.0.0.0",
+                        collapsibleState: 0,
+                        icon: "label.svg"
+                    },
+                    {
+                        label: "resources",
+                        collapsibleState: 1,
+                        icon: "resources.svg",
+                        children: [
+                            {
+                                label: "SwarmNSG",
+                                collapsibleState: 1,
+                                icon: "nsg.svg",
+                                children: [
+                                    {
+                                        label: "apiVersion: 2017-03-01",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "type: Microsoft.Network/networkSecurityGroups",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "name: SwarmNSG",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "location: [resourceGroup().location]",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "tags",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "any: who there",
+                                                collapsibleState: 0
+                                            },
+                                            {
+                                                label: "displayName: NSG - Swarm",
+                                                collapsibleState: 0
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            );
+        });
+
         test("getChildren: Full tree: all default param types", async () => {
 
-            await testTree(template,
+            await testTree(templateAllParamDefaultTypes,
                 [
                     {
                         label: "$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
@@ -721,17 +798,15 @@ function toTestTreeItem(item: vscode.TreeItem): ITestTreeItem {
 }
 
 function getTextAtSpan(span: Span): string {
-    return template.substr(span.startIndex, span.length);
+    return templateAllParamDefaultTypes.substr(span.startIndex, span.length);
 }
 
 async function showNewTextDocument(text: string): Promise<vscode.TextEditor> {
     let textDocument = await vscode.workspace.openTextDocument({
         language: "jsonc",
-        content: template
+        content: text
     });
-    let editor = await vscode.window.showTextDocument(textDocument);
-    await writeToEditor(editor, template);
-    return editor;
+    return await vscode.window.showTextDocument(textDocument);
 }
 
 async function writeToEditor(editor: vscode.TextEditor, data: string): Promise<void> {
@@ -745,7 +820,7 @@ async function writeToEditor(editor: vscode.TextEditor, data: string): Promise<v
     });
 }
 
-const template: string = `
+const templateAllParamDefaultTypes: string = `
             {
                 "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -109,7 +109,7 @@ suite("TreeView", async (): Promise<void> => {
         }
 
         async function testLabels(template: string, expected: Partial<ITestTreeItem>[]): Promise<void> {
-            testTree(template, expected, ["label"]);
+            await testTree(template, expected, ["label"]);
         }
 
         function getTree(element?: string): ITestTreeItem[] {

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
+// tslint:disable:max-func-body-length
+
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as Json from "../src/JSON";
@@ -29,7 +31,7 @@ suite("TreeView", async (): Promise<void> => {
             mySetup().then(done, () => { assert.fail("Setup failed"); });
         });
 
-        async function testGetChildren(template: string, expected: ITestTreeItem[]): Promise<void> {
+        async function testChildren(template: string, expected: ITestTreeItem[]): Promise<void> {
             let editor = await showNewTextDocument(template);
             let children = provider.getChildren(null);
             let testChildren = children.map(child => {
@@ -40,35 +42,660 @@ suite("TreeView", async (): Promise<void> => {
             assert.deepStrictEqual(testChildren, expected);
         }
 
-        test("getChildren: Full tree: all default param types", async () => {
+        async function testTree(template: string, expected: ITestTreeItem[]): Promise<void> {
+            let editor = await showNewTextDocument(template);
+            let testChildren = getTree(null);
+            assert.deepStrictEqual(testChildren, expected);
+        }
 
-            await testGetChildren(template, [
+        function getTree(element?: string): ITestTreeItem[] {
+            let children = provider.getChildren(element);
+            let testChildren = children.map(child => {
+                let treeItem = provider.getTreeItem(child);
+                let testItem = toTestTreeItem(treeItem);
+
+                if (treeItem.collapsibleState === vscode.TreeItemCollapsibleState.Collapsed) {
+                    // Get subchildren
+                    let testGrandChilderen = getTree(child);
+                    testItem.children = testGrandChilderen;
+                }
+
+                return testItem;
+            });
+
+            return testChildren;
+        }
+
+        test("getChildren: Top level: all default param types", async () => {
+
+            await testChildren(template, [
                 {
                     label: "$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                     collapsibleState: 0,
-                    iconFile: "label.svg"
+                    icon: "label.svg"
                 }, {
                     label: "contentVersion: 1.0.0.0",
                     collapsibleState: 0,
-                    iconFile: "label.svg"
+                    icon: "label.svg"
                 }, {
                     label: "a: undefined", // Until https://github.com/Microsoft/vscode-azurearmtools/issues is fixed
                     collapsibleState: 0,
-                    iconFile: undefined
+                    icon: undefined
                 }, {
                     label: "parameters",
                     collapsibleState: 1,
-                    iconFile: "parameters.svg"
+                    icon: "parameters.svg"
                 }, {
                     label: "variables",
                     collapsibleState: 1,
-                    iconFile: "variables.svg"
+                    icon: "variables.svg"
                 }, {
                     label: "resources",
                     collapsibleState: 1,
-                    iconFile: "resources.svg"
+                    icon: "resources.svg"
                 }
             ]);
+        });
+
+        test("getChildren: Full tree: all default param types", async () => {
+
+            await testTree(template,
+                [
+                    {
+                        label: "$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                        collapsibleState: 0,
+                        icon: "label.svg"
+                    },
+                    {
+                        label: "contentVersion: 1.0.0.0",
+                        collapsibleState: 0,
+                        icon: "label.svg"
+                    },
+                    {
+                        label: "a: undefined",
+                        collapsibleState: 0
+                    },
+                    {
+                        label: "parameters",
+                        collapsibleState: 1,
+                        icon: "parameters.svg",
+                        children: [
+                            {
+                                label: "int",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: int",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: undefined",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "string",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: string",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: hi",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "array",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: array",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "object",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: object",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "hi: there",
+                                                collapsibleState: 0
+                                            },
+                                            {
+                                                label: "one: undefined",
+                                                collapsibleState: 0
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                label: "bool",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: bool",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: false",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "null",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: bool",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: undefined",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "undefined",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: string",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: undefined",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "securestring",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: securestring",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: string",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "secureObject",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: secureObject",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "hi: there",
+                                                collapsibleState: 0
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                label: "windowsOSVersion",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: string",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue: 2016-Datacenter-with-Containers",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "allowedValues",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "metadata",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "description: The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter.",
+                                                collapsibleState: 0
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                label: "hostVMprofile",
+                                collapsibleState: 1,
+                                icon: "parameters.svg",
+                                children: [
+                                    {
+                                        label: "type: object",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "defaultValue",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "hostvmSku",
+                                                collapsibleState: 1,
+                                                children: [
+                                                    {
+                                                        label: "type: string",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "defaultValue: Standard_A1",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "metadata",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "description: Size of VMs in the VM Scale Set hosting docker swarm hosts.",
+                                                                collapsibleState: 0
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                label: "windowsOSVersion",
+                                                collapsibleState: 1,
+                                                children: [
+                                                    {
+                                                        label: "type: string",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "defaultValue: 2016-Datacenter-with-Containers",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "allowedValues",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "metadata",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "description: The Windows version for the host VMs, please note that if you choose SAC version then you need to choose SemiAnnual for offer",
+                                                                collapsibleState: 0
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                label: "offer",
+                                                collapsibleState: 1,
+                                                children: [
+                                                    {
+                                                        label: "type: string",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "defaultValue: WindowsServer",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "allowedValues",
+                                                        collapsibleState: 0
+                                                    },
+                                                    {
+                                                        label: "metadata",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "description: Choose WindowsServerSemiannual for SAC channel",
+                                                                collapsibleState: 0
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        label: "variables",
+                        collapsibleState: 1,
+                        icon: "variables.svg",
+                        children: [
+                            {
+                                label: "swarmhostimageReference",
+                                collapsibleState: 1,
+                                icon: "variables.svg",
+                                children: [
+                                    {
+                                        label: "publisher: MicrosoftWindowsServer",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "offer: [parameters('hostVMprofile').offer]",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "sku: [parameters('hostVMprofile').windowsOSVersion]",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "version: latest",
+                                        collapsibleState: 0
+                                    }
+                                ]
+                            },
+                            {
+                                label: "namingInfix: [toLower(substring(concat(parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
+                                collapsibleState: 0,
+                                icon: "variables.svg"
+                            },
+                            {
+                                label: "addressPrefix: 10.0.0.0/16",
+                                collapsibleState: 0,
+                                icon: "variables.svg"
+                            }
+                        ]
+                    },
+                    {
+                        label: "resources",
+                        collapsibleState: 1,
+                        icon: "resources.svg",
+                        children: [
+                            {
+                                label: "[variables('virtualNetworkName')]",
+                                collapsibleState: 1,
+                                icon: "virtualnetworks.svg",
+                                children: [
+                                    {
+                                        label: "type: Microsoft.Network/virtualNetworks",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "name: [variables('virtualNetworkName')]",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "location: [resourceGroup().location]",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "apiVersion: 2017-06-01",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "properties",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "addressSpace",
+                                                collapsibleState: 1,
+                                                children: [
+                                                    {
+                                                        label: "addressPrefixes",
+                                                        collapsibleState: 0
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                label: "subnets",
+                                                collapsibleState: 1,
+                                                children: [
+                                                    {
+                                                        label: "[variables('subnetName')]",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "name: [variables('subnetName')]",
+                                                                collapsibleState: 0
+                                                            },
+                                                            {
+                                                                label: "properties",
+                                                                collapsibleState: 1,
+                                                                children: [
+                                                                    {
+                                                                        label: "addressPrefix: [variables('subnetPrefix')]",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "networkSecurityGroup",
+                                                                        collapsibleState: 1,
+                                                                        children: [
+                                                                            {
+                                                                                label: "id: [resourceId('Microsoft.Network/networkSecurityGroups', 'SwarmNSG')]",
+                                                                                collapsibleState: 0
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        label: "[variables('appGwSubnetName')]",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "name: [variables('appGwSubnetName')]",
+                                                                collapsibleState: 0
+                                                            },
+                                                            {
+                                                                label: "properties",
+                                                                collapsibleState: 1,
+                                                                children: [
+                                                                    {
+                                                                        label: "addressPrefix: [variables('appGwSubnetPrefix')]",
+                                                                        collapsibleState: 0
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                label: "SwarmNSG",
+                                collapsibleState: 1,
+                                icon: "nsg.svg",
+                                children: [
+                                    {
+                                        label: "apiVersion: 2017-03-01",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "type: Microsoft.Network/networkSecurityGroups",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "name: SwarmNSG",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "location: [resourceGroup().location]",
+                                        collapsibleState: 0
+                                    },
+                                    {
+                                        label: "tags",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "any: who there",
+                                                collapsibleState: 0
+                                            },
+                                            {
+                                                label: "displayName: NSG - Swarm",
+                                                collapsibleState: 0
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        label: "properties",
+                                        collapsibleState: 1,
+                                        children: [
+                                            {
+                                                label: "securityRules",
+                                                collapsibleState: 1,
+                                                children: [
+                                                    {
+                                                        label: "rdp-rule",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "name: rdp-rule",
+                                                                collapsibleState: 0
+                                                            },
+                                                            {
+                                                                label: "properties",
+                                                                collapsibleState: 1,
+                                                                children: [
+                                                                    {
+                                                                        label: "description: Allow RDP",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "protocol: Tcp",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "sourcePortRange: *",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "destinationPortRange: 3389",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "sourceAddressPrefix: Internet",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "destinationAddressPrefix: *",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "access: Allow",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "priority: undefined",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "direction: Inbound",
+                                                                        collapsibleState: 0
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        label: "Docker-API",
+                                                        collapsibleState: 1,
+                                                        children: [
+                                                            {
+                                                                label: "name: Docker-API",
+                                                                collapsibleState: 0
+                                                            },
+                                                            {
+                                                                label: "properties",
+                                                                collapsibleState: 1,
+                                                                children: [
+                                                                    {
+                                                                        label: "description: Allow WEB",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "protocol: Tcp",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "sourcePortRange: *",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "destinationPortRange: 2376",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "sourceAddressPrefix: Internet",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "destinationAddressPrefix: *",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "access: Allow",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "priority: undefined",
+                                                                        collapsibleState: 0
+                                                                    },
+                                                                    {
+                                                                        label: "direction: Inbound",
+                                                                        collapsibleState: 0
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            )
         });
     });
 });
@@ -76,15 +703,21 @@ suite("TreeView", async (): Promise<void> => {
 type ITestTreeItem = {
     label: string;
     collapsibleState: vscode.TreeItemCollapsibleState;
-    iconFile: string;
+    icon?: string;
+    children?: ITestTreeItem[];
 }
 
 function toTestTreeItem(item: vscode.TreeItem): ITestTreeItem {
-    return {
+    let testItem: ITestTreeItem = {
         label: item.label,
-        collapsibleState: item.collapsibleState,
-        iconFile: item.iconPath ? path.basename(item.iconPath.toString()) : undefined
+        collapsibleState: item.collapsibleState
+    };
+
+    if (item.iconPath) {
+        testItem.icon = path.basename(item.iconPath.toString());
     }
+
+    return testItem;
 }
 
 function getTextAtSpan(span: Span): string {
@@ -256,6 +889,7 @@ const template: string = `
                         "name": "SwarmNSG",
                         "location": "[resourceGroup().location]",
                         "tags": {
+                            "any": "who there",
                             "displayName": "NSG - Swarm"
                         },
                         "properties": {


### PR DESCRIPTION
Make labels in the tree more useful by:
1) using the displayName tag if it exists (like the VS extension)
2) shorten name labels (similar to the VS extension)
   e.g. "[(variables('a')+variables('abc'))]" => "(<a>+<abc>)"

Fixes #80 