### PR TITLE
Update vscode-extenion-telemetry dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "moment": "^2.17.1",
     "open": "^0.0.5",
     "vscode-azureextensionui": "~0.12.0",
-    "vscode-extension-telemetry": "^0.0.15"
+    "vscode-extension-telemetry": "^0.0.22"
   }
 }


### PR DESCRIPTION
The latest version of `vscode-extension-telemtetry` module (0.0.22) uses the latest version of `applicationinsights` module (1.0.5) which has the fix to prevent unnecessary patching of the require and other 3rd party modules. 

This PR updates the version of `vscode-extension-telemetry` so that we can avoid such patching and any unforeseen consequences of the same in VS Code

For more details, please see https://github.com/Microsoft/vscode-extension-telemetry/issues/16

**Please note:** Once https://github.com/Microsoft/vscode-azuretools/pull/276 is merged a new version is updated, then this extension needs to be updated to use the latest of `vscode-azureextensionui`