### PR TITLE
Better handle async errors

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,13 @@
             "type": "npm",
             "script": "lint",
             "problemMatcher": "$tslint5"
+        },
+        {
+            "type": "npm",
+            "script": "all",
+            "problemMatcher": [
+                "$eslint-compact"
+            ]
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,16 @@
         "buffer-equal": "^1.0.0"
       }
     },
+    "applicationinsights": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.8.tgz",
+      "integrity": "sha512-KzOOGdphOS/lXWMFZe5440LUdFbrLpMvh2SaRxn7BmiI550KAoSb2gIhiq6kJZ9Ir3AxRRztjhzif+e5P5IXIg==",
+      "requires": {
+        "diagnostic-channel": "0.2.0",
+        "diagnostic-channel-publishers": "0.2.1",
+        "zone.js": "0.7.6"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -2325,6 +2335,19 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "diagnostic-channel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
+      "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -2490,9 +2513,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -5300,12 +5323,12 @@
       "dev": true
     },
     "jwa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
-      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.3.0.tgz",
+      "integrity": "sha512-SxObIyzv9a6MYuZYaSN6DhSm9j3+qkokwvCB0/OTSV5ylPq1wUQiygZQcHT5Qlux0I5kmISx3J86TxKhuefItg==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -9602,9 +9625,9 @@
       }
     },
     "vscode-azureextensionui": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.20.1.tgz",
-      "integrity": "sha512-j9JPccGn097bk887tJ6Fn3TuBOCufUF0ENgiB8JybOnjdXziQcG3ovR7KBlwa2HkN9bvt32B467SmX6enLmymw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.20.2.tgz",
+      "integrity": "sha512-YwlS30q9cBFu8ZKb4WgAP9DmXgQJXEsUwUGsHMt07gwb9+seK/J1DdhvZXm16wCyTdPoa9WrZmGbFIHSbou7sQ==",
       "requires": {
         "azure-arm-resource": "^3.0.0-preview",
         "azure-arm-storage": "^3.1.0",
@@ -9636,31 +9659,6 @@
       "integrity": "sha512-TkKKG/B/J94DP5qf6xWB4YaqlhWDg6zbbqVx7Bz//stLQNnfE9XS1xm3f6fl24c5+bnEK0/wHgMgZYKIKxPeUA==",
       "requires": {
         "applicationinsights": "1.0.8"
-      },
-      "dependencies": {
-        "applicationinsights": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.8.tgz",
-          "integrity": "sha512-KzOOGdphOS/lXWMFZe5440LUdFbrLpMvh2SaRxn7BmiI550KAoSb2gIhiq6kJZ9Ir3AxRRztjhzif+e5P5IXIg==",
-          "requires": {
-            "diagnostic-channel": "0.2.0",
-            "diagnostic-channel-publishers": "0.2.1",
-            "zone.js": "0.7.6"
-          }
-        },
-        "diagnostic-channel": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-          "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "diagnostic-channel-publishers": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
-          "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
-        }
       }
     },
     "vscode-nls": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9625,9 +9625,9 @@
       }
     },
     "vscode-azureextensionui": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.20.2.tgz",
-      "integrity": "sha512-YwlS30q9cBFu8ZKb4WgAP9DmXgQJXEsUwUGsHMt07gwb9+seK/J1DdhvZXm16wCyTdPoa9WrZmGbFIHSbou7sQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.20.3.tgz",
+      "integrity": "sha512-lvkFKfCP8l+GIYQtNv6ff0Gc5N4muxsMhBKGjWETfhpBI6+WrdleMinJ6iyh7CepGW05U1JVXkcgEqEJ/VIlVw==",
       "requires": {
         "azure-arm-resource": "^3.0.0-preview",
         "azure-arm-storage": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/fs-extra": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
+      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -3258,9 +3267,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9607,6 +9616,18 @@
         "semver": "^5.6.0",
         "vscode-extension-telemetry": "^0.1.0",
         "vscode-nls": "^4.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
       }
     },
     "vscode-extension-telemetry": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^8.0.17",
     "@types/opn": "^5.1.0",
+    "@types/fs-extra": "^5.0.5",
     "gulp": "^4.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
@@ -97,6 +98,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
+    "fs-extra": "^7.0.1",
     "moment": "^2.24.0",
     "opn": "^5.4.0",
     "vscode-azureextensionui": "~0.20.0"

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "fs-extra": "^7.0.1",
     "moment": "^2.24.0",
     "opn": "^5.4.0",
-    "vscode-azureextensionui": "~0.20.2"
+    "vscode-azureextensionui": "~0.20.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "fs-extra": "^7.0.1",
     "moment": "^2.24.0",
     "opn": "^5.4.0",
-    "vscode-azureextensionui": "~0.20.0"
+    "vscode-azureextensionui": "~0.20.2"
   }
 }

--- a/src/AzureRMAssets.ts
+++ b/src/AzureRMAssets.ts
@@ -2,51 +2,42 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
-import * as fs from "fs";
+import * as fse from 'fs-extra';
 import * as path from "path";
 
 import { SurveyMetadata } from "./SurveyMetadata";
-
-// tslint:disable:promise-function-async // Grandfathered in
 
 /**
  * An accessor class for the Azure RM storage account.
  */
 // tslint:disable-next-line:no-unnecessary-class // Grandfathered in
 export class AzureRMAssets {
-    private static _versionRedirects: Promise<VersionRedirect[]>;
-    private static _currentVersionRedirectUri: Promise<string>;
-    private static _surveyMetadataUri: Promise<string>;
-    private static _surveyMetadata: Promise<SurveyMetadata>;
-    private static _functionMetadataUri: Promise<string>;
-    private static _functionsMetadata: Promise<FunctionsMetadata>;
-
-    /**
-     * Indicates which version container in the storage account the extension will use for its
-     * metadata.
-     */
-    public static get currentPublishVersion(): string {
-        return "azuresdk-3.0.0";
-    }
+    private static _surveyMetadataPromise: Promise<SurveyMetadata>;
+    private static _functionsMetadataPromise: Promise<FunctionsMetadata>;
 
     // For test dependency injection only
     public static setFunctionsMetadata(metadataString: string): void {
-        AzureRMAssets._functionsMetadata = Promise.resolve(metadataString)
-            .then(FunctionMetadata.fromString)
-            .then((array: FunctionMetadata[]) => new FunctionsMetadata(array));
-
+        AzureRMAssets._functionsMetadataPromise = new Promise<FunctionsMetadata>(async (resolve, reject) => {
+            let array = await FunctionMetadata.fromString(metadataString);
+            resolve(new FunctionsMetadata(array));
+        });
     }
 
-    public static getFunctionsMetadata(): Promise<FunctionsMetadata> {
-        if (!AzureRMAssets._functionsMetadata) {
-            AzureRMAssets._functionsMetadata = AzureRMAssets.getFunctionMetadataUri()
-                .then(AzureRMAssets.readFile)
-                .then(FunctionMetadata.fromString)
-                .then((array: FunctionMetadata[]) => new FunctionsMetadata(array));
-
+    public static async getFunctionsMetadata(): Promise<FunctionsMetadata> {
+        if (!AzureRMAssets._functionsMetadataPromise) {
+            AzureRMAssets._functionsMetadataPromise = new Promise<FunctionsMetadata>(async (resolve, reject) => {
+                try {
+                    let uri = AzureRMAssets.getFunctionMetadataUri();
+                    let contents = await AzureRMAssets.readFile(uri);
+                    let array: FunctionMetadata[] = await FunctionMetadata.fromString(contents);
+                    resolve(new FunctionsMetadata(array));
+                } catch (err) {
+                    reject(err);
+                }
+            });
         }
 
-        return AzureRMAssets._functionsMetadata;
+        return await AzureRMAssets._functionsMetadataPromise;
     }
 
     public static async getFunctionMetadataFromName(functionName: string): Promise<FunctionMetadata> {
@@ -60,48 +51,34 @@ export class AzureRMAssets {
     /**
      * Get the URI to the file where the function metadata is stored.
      */
-    private static getFunctionMetadataUri(): Promise<string> {
-        if (AzureRMAssets._functionMetadataUri === undefined) {
-            AzureRMAssets._functionMetadataUri = AzureRMAssets.getLocalAssetUri("ExpressionMetadata.json");
+    private static getFunctionMetadataUri(): string {
+        return AzureRMAssets.getLocalAssetUri("ExpressionMetadata.json");
+    }
+
+    private static getLocalAssetUri(assetFileName: string): string {
+        // Relative to dist
+        return path.join(__filename, "..", "..", "assets", assetFileName);
+    }
+
+    private static async readFile(filePath: string): Promise<string> {
+        return await fse.readFile(filePath, "utf8");
+    }
+
+    public static async getSurveyMetadata(): Promise<SurveyMetadata> {
+        if (AzureRMAssets._surveyMetadataPromise === undefined) {
+            AzureRMAssets._surveyMetadataPromise = new Promise<SurveyMetadata>(async (resolve, reject) => {
+                let uri = await AzureRMAssets.getSurveyMetadataUri();
+                let contents = await AzureRMAssets.readFile(uri);
+                let data = await SurveyMetadata.fromString(contents);
+                resolve(data);
+            });
         }
-        return AzureRMAssets._functionMetadataUri;
+        return await AzureRMAssets._surveyMetadataPromise;
     }
 
-    private static getLocalAssetUri(assetFileName: string): Promise<string> {
-        return Promise.resolve<string>(path.join(__filename, "..", "..", "..", "assets", assetFileName));
+    public static getSurveyMetadataUri(): string {
+        return AzureRMAssets.getLocalAssetUri("SurveyMetadata.json");
     }
-
-    private static readFile(filePath: string): Promise<string> {
-        return new Promise<string>((resolve, reject) => fs.readFile(filePath, "utf8", (err, data) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-
-            resolve(data);
-        }));
-    }
-
-    public static getSurveyMetadata(): Promise<SurveyMetadata> {
-        if (AzureRMAssets._surveyMetadata === undefined) {
-            AzureRMAssets._surveyMetadata = AzureRMAssets.getSurveyMetadataUri()
-                .then(AzureRMAssets.readFile)
-                .then(SurveyMetadata.fromString);
-        }
-        return AzureRMAssets._surveyMetadata;
-    }
-
-    public static getSurveyMetadataUri(): Promise<string> {
-        if (AzureRMAssets._surveyMetadataUri === undefined) {
-            AzureRMAssets._surveyMetadataUri = AzureRMAssets.getLocalAssetUri("SurveyMetadata.json");
-        }
-        return AzureRMAssets._surveyMetadataUri;
-    }
-}
-
-export interface VersionRedirect {
-    Version: string;
-    StorageContainerUri: string;
 }
 
 /**

--- a/src/AzureRMAssets.ts
+++ b/src/AzureRMAssets.ts
@@ -18,7 +18,7 @@ export class AzureRMAssets {
     // For test dependency injection only
     public static setFunctionsMetadata(metadataString: string): void {
         AzureRMAssets._functionsMetadataPromise = new Promise<FunctionsMetadata>(async (resolve, reject) => {
-            let array = await FunctionMetadata.fromString(metadataString);
+            let array = FunctionMetadata.fromString(metadataString);
             resolve(new FunctionsMetadata(array));
         });
     }
@@ -29,7 +29,7 @@ export class AzureRMAssets {
                 try {
                     let uri = AzureRMAssets.getFunctionMetadataUri();
                     let contents = await AzureRMAssets.readFile(uri);
-                    let array: FunctionMetadata[] = await FunctionMetadata.fromString(contents);
+                    let array: FunctionMetadata[] = FunctionMetadata.fromString(contents);
                     resolve(new FunctionsMetadata(array));
                 } catch (err) {
                     reject(err);
@@ -67,9 +67,9 @@ export class AzureRMAssets {
     public static async getSurveyMetadata(): Promise<SurveyMetadata> {
         if (AzureRMAssets._surveyMetadataPromise === undefined) {
             AzureRMAssets._surveyMetadataPromise = new Promise<SurveyMetadata>(async (resolve, reject) => {
-                let uri = await AzureRMAssets.getSurveyMetadataUri();
+                let uri = AzureRMAssets.getSurveyMetadataUri();
                 let contents = await AzureRMAssets.readFile(uri);
-                let data = await SurveyMetadata.fromString(contents);
+                let data = SurveyMetadata.fromString(contents);
                 resolve(data);
             });
         }

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -460,6 +460,7 @@ export class AzureRMTools {
             const me = this;
             return await callWithTelemetryAndErrorHandling('provideCompletionItems', async function (this: IActionContext): Promise<vscode.CompletionList | undefined> {
                 let properties = <TelemetryProperties & { completionKind?: string }>this.properties;
+                this.suppressTelemetry = true;
 
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
                 if (context.completionItems) {

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -214,7 +214,7 @@ export class AzureRMTools {
         const me = this;
 
         // Don't wait
-        callWithTelemetryAndErrorHandling('reportDeploymentTemplateErrors', async function (this: IActionContext) {
+        let dontWait = callWithTelemetryAndErrorHandling('reportDeploymentTemplateErrors', async function (this: IActionContext) {
             this.suppressTelemetry = true;
 
             let parseErrors: language.Issue[] = await deploymentTemplate.errors;

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -5,12 +5,11 @@
 // tslint:disable:promise-function-async // Grandfathered in
 
 import * as assert from "assert";
-import * as fs from "fs";
 import opn = require("opn");
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
-import { AzureUserInput, callWithTelemetryAndErrorHandling, createTelemetryReporter, IActionContext, IParsedError, parseError, registerUIExtensionVariables, TelemetryMeasurements, TelemetryProperties } from "vscode-azureextensionui";
+import { AzureUserInput, callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync, createTelemetryReporter, IActionContext, IParsedError, parseError, registerUIExtensionVariables, TelemetryMeasurements, TelemetryProperties, UserCancelledError } from "vscode-azureextensionui";
 import { AzureRMAssets } from "./AzureRMAssets";
 import * as Completion from "./Completion";
 import { DeploymentTemplate } from "./DeploymentTemplate";
@@ -18,7 +17,6 @@ import { ext } from "./extensionVariables";
 import { Histogram } from "./Histogram";
 import * as Hover from "./Hover";
 import { IncorrectArgumentsCountIssue } from "./IncorrectArgumentsCountIssue";
-import * as Json from "./JSON";
 import * as language from "./Language";
 import { PositionContext } from "./PositionContext";
 import * as Reference from "./Reference";
@@ -91,38 +89,35 @@ export class AzureRMTools {
         context.subscriptions.push(vscode.window.registerTreeDataProvider("json-outline", jsonOutline));
         context.subscriptions.push(vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => jsonOutline.goToDefinition(range)));
 
-        this.log("Extension Activated");
+        const jsonFileSubscriptionArray: vscode.Disposable[] = [];
 
-        this.logOnError(() => {
-            const jsonFileSubscriptionArray: vscode.Disposable[] = [];
+        vscode.window.onDidChangeActiveTextEditor(this.onActiveTextEditorChanged, this, jsonFileSubscriptionArray);
 
-            vscode.window.onDidChangeActiveTextEditor(this.onActiveTextEditorChanged, this, jsonFileSubscriptionArray);
+        vscode.workspace.onDidChangeConfiguration(this.loadConfiguration, this, jsonFileSubscriptionArray);
 
-            vscode.workspace.onDidChangeConfiguration(this.loadConfiguration, this, jsonFileSubscriptionArray);
+        vscode.workspace.onDidOpenTextDocument(this.onDocumentOpened, this, jsonFileSubscriptionArray);
+        vscode.workspace.onDidChangeTextDocument(this.onDocumentChanged, this, jsonFileSubscriptionArray);
+        vscode.workspace.onDidSaveTextDocument(this.onDocumentSaved, this, jsonFileSubscriptionArray);
 
-            vscode.workspace.onDidOpenTextDocument(this.onDocumentOpened, this, jsonFileSubscriptionArray);
-            vscode.workspace.onDidChangeTextDocument(this.onDocumentChanged, this, jsonFileSubscriptionArray);
-            vscode.workspace.onDidSaveTextDocument(this.onDocumentSaved, this, jsonFileSubscriptionArray);
+        this._jsonFileSubscriptions = vscode.Disposable.from(...jsonFileSubscriptionArray);
 
-            this._jsonFileSubscriptions = vscode.Disposable.from(...jsonFileSubscriptionArray);
-
-            const activeEditor: vscode.TextEditor = vscode.window.activeTextEditor;
-            if (activeEditor) {
-                this.updateDeploymentTemplate(activeEditor.document);
-            }
-        });
+        const activeEditor: vscode.TextEditor = vscode.window.activeTextEditor;
+        if (activeEditor) {
+            this.updateDeploymentTemplate(activeEditor.document);
+        }
     }
 
     public dispose(): void {
-        this.logOnError(() => {
-            if (this._deploymentTemplateFileSubscriptions) {
-                this._deploymentTemplateFileSubscriptions.dispose();
+        const me = this;
+        callWithTelemetryAndErrorHandlingSync('dispose', function (this: IActionContext) {
+            this.properties.isActivationEvent = 'true';
+
+            if (me._deploymentTemplateFileSubscriptions) {
+                me._deploymentTemplateFileSubscriptions.dispose();
             }
 
-            this._jsonFileSubscriptions.dispose();
+            me._jsonFileSubscriptions.dispose();
         });
-
-        this.log("Extension Deactivated");
     }
 
     private getDeploymentTemplate(document: vscode.TextDocument): DeploymentTemplate {
@@ -136,7 +131,16 @@ export class AzureRMTools {
     }
 
     private updateDeploymentTemplate(document: vscode.TextDocument): void {
-        if (document) {
+        if (!document) {
+            return;
+        }
+
+        const me = this;
+        callWithTelemetryAndErrorHandlingSync('updateDeploymentTemplate', function (this: IActionContext) {
+            this.suppressErrorDisplay = true;
+            this.suppressTelemetry = true;
+            this.properties.isActivationEvent = 'true';
+
             let foundDeploymentTemplate = false;
 
             if (document.getText() &&
@@ -148,14 +152,14 @@ export class AzureRMTools {
                 // If the documentUri is not in our dictionary of deployment templates, then we
                 // know that this document was opened (as opposed to changed/updated).
                 let stopwatch: Stopwatch;
-                if (!this._deploymentTemplates[documentUri]) {
+                if (!me._deploymentTemplates[documentUri]) {
                     stopwatch = new Stopwatch();
                     stopwatch.start();
                 }
 
                 let deploymentTemplate: DeploymentTemplate = new DeploymentTemplate(document.getText(), documentUri);
                 if (deploymentTemplate.hasValidSchemaUri()) {
-                    let surveyInfo: SurveyInfo = this.updateSurveySettingsFromOpeningTemplate();
+                    let surveyInfo: SurveyInfo = me.updateSurveySettingsFromOpeningTemplate();
 
                     // If this is the first deployment template to be opened,
                     // then we need to register all of our deployment template
@@ -164,11 +168,11 @@ export class AzureRMTools {
                     // performance impact that might occur if these events
                     // are fired for all JSON files, not just deployment
                     // templates.
-                    if (Object.keys(this._deploymentTemplates).length === 0) {
-                        this.initializeExtension(surveyInfo);
+                    if (Object.keys(me._deploymentTemplates).length === 0) {
+                        me.initializeExtension(surveyInfo);
                     }
 
-                    this._deploymentTemplates[documentUri] = deploymentTemplate;
+                    me._deploymentTemplates[documentUri] = deploymentTemplate;
                     foundDeploymentTemplate = true;
 
                     // We only initialized the stopwatch if the deployment template was being
@@ -176,7 +180,7 @@ export class AzureRMTools {
                     // template is being edited.
                     if (stopwatch) {
                         stopwatch.stop();
-                        this.log(
+                        ext.reporter.sendTelemetryEvent(
                             "Deployment Template Opened",
                             {
                             },
@@ -185,10 +189,10 @@ export class AzureRMTools {
                                 parseDurationInMilliseconds: stopwatch.duration.totalMilliseconds
                             });
 
-                        this.logFunctionCounts(deploymentTemplate);
+                        me.logFunctionCounts(deploymentTemplate);
                     }
 
-                    this.reportDeploymentTemplateErrors(document, deploymentTemplate);
+                    me.reportDeploymentTemplateErrors(document, deploymentTemplate);
                 }
             }
 
@@ -201,30 +205,31 @@ export class AzureRMTools {
                 // template (the $schema property changed to not be a
                 // deployment template schema). In either case, we should
                 // remove the deployment template from our cache.
-                this.closeDeploymentTemplate(document);
+                me.closeDeploymentTemplate(document);
             }
-        }
+        });
     }
 
     private reportDeploymentTemplateErrors(document: vscode.TextDocument, deploymentTemplate: DeploymentTemplate): void {
-        deploymentTemplate.errors
-            .then((parseErrors: language.Issue[]) => {
-                const diagnostics: vscode.Diagnostic[] = [];
+        const me = this;
 
-                for (const error of parseErrors) {
-                    diagnostics.push(this.getVSCodeDiagnosticFromIssue(deploymentTemplate, error, vscode.DiagnosticSeverity.Error));
-                }
+        // Don't wait
+        callWithTelemetryAndErrorHandling('reportDeploymentTemplateErrors', async function (this: IActionContext) {
+            this.suppressTelemetry = true;
 
-                for (const warning of deploymentTemplate.warnings) {
-                    diagnostics.push(this.getVSCodeDiagnosticFromIssue(deploymentTemplate, warning, vscode.DiagnosticSeverity.Warning));
-                }
+            let parseErrors: language.Issue[] = await deploymentTemplate.errors;
+            const diagnostics: vscode.Diagnostic[] = [];
 
-                this._diagnosticsCollection.set(document.uri, diagnostics);
-            })
-            // tslint:disable-next-line:no-any
-            .catch((error: any) => {
-                this.logError("UnhandledError", error);
-            });
+            for (const error of parseErrors) {
+                diagnostics.push(me.getVSCodeDiagnosticFromIssue(deploymentTemplate, error, vscode.DiagnosticSeverity.Error));
+            }
+
+            for (const warning of deploymentTemplate.warnings) {
+                diagnostics.push(me.getVSCodeDiagnosticFromIssue(deploymentTemplate, warning, vscode.DiagnosticSeverity.Warning));
+            }
+
+            me._diagnosticsCollection.set(document.uri, diagnostics);
+        });
     }
 
     /**
@@ -314,7 +319,7 @@ export class AzureRMTools {
                         vscode.window.showInformationMessage(message, ...options).then((selectedOption: string) => {
                             surveyInfo.settings.previousSurveyPromptDateAndTime = Date.now();
 
-                            this.log("Survey Prompt", {
+                            ext.reporter.sendTelemetryEvent('Survey Prompt', {
                                 selectedOption: selectedOption
                             });
 
@@ -331,7 +336,7 @@ export class AzureRMTools {
                 })
                 // tslint:disable-next-line:no-any
                 .catch((error: any) => {
-                    this.logError("Failed To Get Survey Metadata", error);
+                    ext.reporter.sendTelemetryEvent("Failed To Get Survey Metadata", <TelemetryProperties>{ errorMessage: parseError(error).message });
                 });
         }
     }
@@ -341,7 +346,7 @@ export class AzureRMTools {
      * in a relatively stable state, such as after first opening
      */
     private logFunctionCounts(deploymentTemplate: DeploymentTemplate): void {
-        let me = this;
+        const me = this;
 
         // Don't wait for promise
         let dummyPromise = callWithTelemetryAndErrorHandling("tle.stats", async function (this: IActionContext) {
@@ -418,142 +423,121 @@ export class AzureRMTools {
         }
     }
 
-    private onProvideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover> {
-        let result: Promise<vscode.Hover> = Promise.resolve(null);
+    private async onProvideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover> {
+        const deploymentTemplate = this.getDeploymentTemplate(document);
+        if (deploymentTemplate) {
+            const me = this;
+            return await callWithTelemetryAndErrorHandling('Hover', async function (this: IActionContext) {
+                let properties = <TelemetryProperties & { hoverType?: string; tleFunctionName: string; }>this.properties;
 
-        this.logOnError(() => {
-            const deploymentTemplate = this.getDeploymentTemplate(document);
-            if (deploymentTemplate) {
                 const context = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
                 if (context.hoverInfo) {
-                    result = context.hoverInfo.then((hoverInfo: Hover.Info) => {
-                        let hover: vscode.Hover = null;
+                    let hoverInfo: Hover.Info = await context.hoverInfo;
+                    let hover: vscode.Hover = null;
 
-                        if (hoverInfo) {
-                            if (hoverInfo instanceof Hover.FunctionInfo) {
-                                this.log("Hover", {
-                                    hoverType: "TLE Function",
-                                    tleFunctionName: hoverInfo.functionName
-                                });
-                            } else if (hoverInfo instanceof Hover.ParameterReferenceInfo) {
-                                this.log("Hover", {
-                                    hoverType: "Parameter Reference"
-                                });
-                            } else if (hoverInfo instanceof Hover.VariableReferenceInfo) {
-                                this.log("Hover", {
-                                    hoverType: "Variable Reference"
-                                });
-                            }
-
-                            const hoverRange: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, hoverInfo.span);
-                            hover = new vscode.Hover(hoverInfo.getHoverText(), hoverRange);
+                    if (hoverInfo) {
+                        if (hoverInfo instanceof Hover.FunctionInfo) {
+                            properties.hoverType = "TLE Function";
+                            properties.tleFunctionName = hoverInfo.functionName;
+                        } else if (hoverInfo instanceof Hover.ParameterReferenceInfo) {
+                            properties.hoverType = "Parameter Reference";
+                        } else if (hoverInfo instanceof Hover.VariableReferenceInfo) {
+                            properties.hoverType = "Variable Reference";
                         }
 
+                        const hoverRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, hoverInfo.span);
+                        hover = new vscode.Hover(hoverInfo.getHoverText(), hoverRange);
                         return hover;
-                    });
+                    }
                 }
-            }
-        });
-
-        // tslint:disable-next-line:no-any
-        return result.catch((error: any) => {
-            this.logError("UnhandledError", error);
-            return undefined;
-        });
+            });
+        }
     }
 
-    private onProvideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.CompletionList> {
-        let result: Promise<vscode.CompletionList> = Promise.resolve(null);
+    private async onProvideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.CompletionList> {
+        const deploymentTemplate = this.getDeploymentTemplate(document);
+        if (deploymentTemplate) {
+            const me = this;
+            return await callWithTelemetryAndErrorHandling('provideCompletionItems', async function (this: IActionContext): Promise<vscode.CompletionList | undefined> {
+                let properties = <TelemetryProperties & { completionKind?: string }>this.properties;
 
-        this.logOnError(() => {
-            const deploymentTemplate = this.getDeploymentTemplate(document);
-            if (deploymentTemplate) {
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
                 if (context.completionItems) {
+                    let completionItemArray: Completion.Item[] = await context.completionItems;
+                    const completionItems: vscode.CompletionItem[] = [];
+                    for (const completion of completionItemArray) {
+                        const insertRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, completion.insertSpan);
 
-                    result = context.completionItems.then((completionItemArray: Completion.Item[]) => {
-                        const completionItems: vscode.CompletionItem[] = [];
-                        for (const completion of completionItemArray) {
-                            const insertRange: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, completion.insertSpan);
+                        const completionToAdd = new vscode.CompletionItem(completion.name);
+                        completionToAdd.range = insertRange;
+                        completionToAdd.insertText = new vscode.SnippetString(completion.insertText);
+                        completionToAdd.detail = completion.detail;
+                        completionToAdd.documentation = completion.description;
 
-                            const completionToAdd = new vscode.CompletionItem(completion.name);
-                            completionToAdd.range = insertRange;
-                            completionToAdd.insertText = new vscode.SnippetString(completion.insertText);
-                            completionToAdd.detail = completion.detail;
-                            completionToAdd.documentation = completion.description;
+                        switch (completion.kind) {
+                            case Completion.CompletionKind.Function:
+                                completionToAdd.kind = vscode.CompletionItemKind.Function;
+                                break;
 
-                            switch (completion.kind) {
-                                case Completion.CompletionKind.Function:
-                                    completionToAdd.kind = vscode.CompletionItemKind.Function;
-                                    break;
+                            case Completion.CompletionKind.Parameter:
+                            case Completion.CompletionKind.Variable:
+                                completionToAdd.kind = vscode.CompletionItemKind.Variable;
+                                break;
 
-                                case Completion.CompletionKind.Parameter:
-                                case Completion.CompletionKind.Variable:
-                                    completionToAdd.kind = vscode.CompletionItemKind.Variable;
-                                    break;
+                            case Completion.CompletionKind.Property:
+                                completionToAdd.kind = vscode.CompletionItemKind.Field;
+                                break;
 
-                                case Completion.CompletionKind.Property:
-                                    completionToAdd.kind = vscode.CompletionItemKind.Field;
-                                    break;
-
-                                default:
-                                    assert.fail(`Unrecognized Completion.Type: ${completion.kind}`);
-                                    break;
-                            }
-
-                            completionItems.push(completionToAdd);
+                            default:
+                                assert.fail(`Unrecognized Completion.Type: ${completion.kind}`);
+                                break;
                         }
-                        return new vscode.CompletionList(completionItems, true);
-                    });
-                }
-            }
-        });
+                        properties.completionKind = vscode.CompletionItemKind[completionToAdd.kind];
 
-        // tslint:disable-next-line:no-any
-        return result.catch((error: any) => {
-            this.logError("UnhandledError", error);
-            return undefined;
-        });
+                        completionItems.push(completionToAdd);
+                    }
+                    return new vscode.CompletionList(completionItems, true);
+                }
+            });
+        }
     }
 
     private onProvideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.Location {
-        let result: vscode.Location = null;
+        const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
+        if (deploymentTemplate) {
+            const me = this;
+            return callWithTelemetryAndErrorHandlingSync('Go To Definition', function (this: IActionContext) {
+                let properties = <TelemetryProperties & { definitionType?: string }>this.properties;
+                let result: vscode.Location = null;
 
-        this.logOnError(() => {
-            const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
-            if (deploymentTemplate) {
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
 
                 let definitionType: string = "no definition";
                 if (context.parameterDefinition) {
                     const locationUri: vscode.Uri = vscode.Uri.parse(deploymentTemplate.documentId);
-                    const definitionRange: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, context.parameterDefinition.span);
+                    const definitionRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, context.parameterDefinition.span);
                     result = new vscode.Location(locationUri, definitionRange);
                     definitionType = "parameter";
                 } else if (context.variableDefinition) {
                     const locationUri: vscode.Uri = vscode.Uri.parse(deploymentTemplate.documentId);
-                    const definitionRange: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, context.variableDefinition.span);
+                    const definitionRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, context.variableDefinition.span);
                     result = new vscode.Location(locationUri, definitionRange);
                     definitionType = "variable";
                 }
 
-                this.log("Go To Definition", {
-                    definitionType: definitionType
-                });
-            }
-        });
-
-        return result;
+                properties.definitionType = definitionType;
+                return result;
+            });
+        }
     }
 
     private onProvideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): vscode.Location[] {
-        const result: vscode.Location[] = [];
-
-        this.logOnError(() => {
-            const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
-            if (deploymentTemplate) {
+        const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
+        if (deploymentTemplate) {
+            const me = this;
+            return callWithTelemetryAndErrorHandlingSync('Find References', function (this: IActionContext) {
+                const results: vscode.Location[] = [];
                 const locationUri: vscode.Uri = vscode.Uri.parse(deploymentTemplate.documentId);
-
                 const positionContext: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
 
                 const references: Reference.List = positionContext.references;
@@ -574,64 +558,54 @@ export class AzureRMTools {
                             break;
                     }
 
-                    this.log("Find References", {
-                        referenceType: referenceType
-                    });
+                    this.properties.referenceType = referenceType;
 
                     for (const span of references.spans) {
-                        const referenceRange: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, span);
-                        result.push(new vscode.Location(locationUri, referenceRange));
+                        const referenceRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, span);
+                        results.push(new vscode.Location(locationUri, referenceRange));
                     }
                 }
-            }
-        });
 
-        return result;
+                return results;
+            });
+        }
     }
 
-    private onProvideSignatureHelp(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.SignatureHelp> {
-        let result: Promise<vscode.SignatureHelp> = Promise.resolve(null);
-
-        this.logOnError(() => {
-            const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
-            if (deploymentTemplate) {
+    private async onProvideSignatureHelp(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.SignatureHelp | undefined> {
+        const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
+        if (deploymentTemplate) {
+            return await callWithTelemetryAndErrorHandling('provideSignatureHelp', async () => {
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
 
-                result = context.signatureHelp.then((functionSignatureHelp: TLE.FunctionSignatureHelp) => {
-                    let signatureHelp: vscode.SignatureHelp = null;
+                let functionSignatureHelp: TLE.FunctionSignatureHelp = await context.signatureHelp;
+                let signatureHelp: vscode.SignatureHelp;
 
-                    if (functionSignatureHelp) {
+                if (functionSignatureHelp) {
 
-                        const signatureInformation = new vscode.SignatureInformation(functionSignatureHelp.functionMetadata.usage, functionSignatureHelp.functionMetadata.description);
-                        signatureInformation.parameters = [];
-                        for (const parameterName of functionSignatureHelp.functionMetadata.parameters) {
-                            signatureInformation.parameters.push(new vscode.ParameterInformation(parameterName));
-                        }
-
-                        signatureHelp = new vscode.SignatureHelp();
-                        signatureHelp.activeParameter = functionSignatureHelp.activeParameterIndex;
-                        signatureHelp.activeSignature = 0;
-                        signatureHelp.signatures = [signatureInformation];
+                    const signatureInformation = new vscode.SignatureInformation(functionSignatureHelp.functionMetadata.usage, functionSignatureHelp.functionMetadata.description);
+                    signatureInformation.parameters = [];
+                    for (const parameterName of functionSignatureHelp.functionMetadata.parameters) {
+                        signatureInformation.parameters.push(new vscode.ParameterInformation(parameterName));
                     }
 
-                    return signatureHelp;
-                });
-            }
-        });
+                    signatureHelp = new vscode.SignatureHelp();
+                    signatureHelp.activeParameter = functionSignatureHelp.activeParameterIndex;
+                    signatureHelp.activeSignature = 0;
+                    signatureHelp.signatures = [signatureInformation];
+                }
 
-        // tslint:disable-next-line:no-any
-        return result.catch((error: any) => {
-            this.logError("UnhandledError", error);
-            return undefined;
-        });
+                return signatureHelp;
+            });
+        }
     }
 
     private onProvideRename(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): vscode.WorkspaceEdit {
-        const result: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+        const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
+        if (deploymentTemplate) {
+            const me = this;
+            return callWithTelemetryAndErrorHandlingSync('Rename', function (this: IActionContext) {
+                const result: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
 
-        this.logOnError(() => {
-            const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
-            if (deploymentTemplate) {
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
                 const referenceList: Reference.List = context.references;
                 if (referenceList) {
@@ -652,34 +626,47 @@ export class AzureRMTools {
                     const documentUri: vscode.Uri = vscode.Uri.parse(deploymentTemplate.documentId);
 
                     for (const referenceSpan of referenceList.spans) {
-                        const referenceRange: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, referenceSpan);
+                        const referenceRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, referenceSpan);
                         result.replace(documentUri, referenceRange, newName);
                     }
                 } else {
-                    vscode.window.showInformationMessage("You can only rename parameters and variables.");
+                    const message = 'You can only rename parameters and variables.';
+                    vscode.window.showInformationMessage(message);
+                    this.suppressErrorDisplay = true;
+                    throw new Error(message);
                 }
-            }
-        });
 
-        return result;
+                return result;
+            });
+        }
     }
 
     private onActiveTextEditorChanged(): void {
-        this.logOnError(() => {
+        const me = this;
+        callWithTelemetryAndErrorHandlingSync('onActiveTextEditorChanged', function (this: IActionContext) {
+            this.properties.isActivationEvent = 'true';
+            this.suppressErrorDisplay = true;
+            this.suppressTelemetry = true;
+
             let activeEditor: vscode.TextEditor = vscode.window.activeTextEditor;
             if (activeEditor) {
-                if (this.getDeploymentTemplate(activeEditor.document) === undefined) {
-                    this.updateDeploymentTemplate(activeEditor.document);
+                if (me.getDeploymentTemplate(activeEditor.document) === undefined) {
+                    me.updateDeploymentTemplate(activeEditor.document);
                 }
             }
         });
     }
 
     private onTextSelectionChanged(): void {
-        this.logOnError(() => {
+        const me = this;
+        callWithTelemetryAndErrorHandlingSync('onTextSelectionChanged', function (this: IActionContext) {
+            this.properties.isActivationEvent = 'true';
+            this.suppressErrorDisplay = true;
+            this.suppressTelemetry = true;
+
             let editor: vscode.TextEditor = vscode.window.activeTextEditor;
             if (editor) {
-                let deploymentTemplate = this.getDeploymentTemplate(editor.document);
+                let deploymentTemplate = me.getDeploymentTemplate(editor.document);
                 if (deploymentTemplate) {
                     let position = editor.selection.anchor;
                     let context = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
@@ -688,54 +675,61 @@ export class AzureRMTools {
                     let braceHighlightRanges: vscode.Range[] = [];
                     for (let tleHighlightIndex of tleBraceHighlightIndexes) {
                         const highlightSpan = new language.Span(tleHighlightIndex + context.jsonTokenStartIndex, 1);
-                        braceHighlightRanges.push(this.getVSCodeRangeFromSpan(deploymentTemplate, highlightSpan));
+                        braceHighlightRanges.push(me.getVSCodeRangeFromSpan(deploymentTemplate, highlightSpan));
                     }
 
-                    editor.setDecorations(this._braceHighlightDecorationType, braceHighlightRanges);
+                    editor.setDecorations(me._braceHighlightDecorationType, braceHighlightRanges);
                 }
             }
         });
     }
 
     private onDocumentChanged(event: vscode.TextDocumentChangeEvent) {
-        this.logOnError(() => {
-            this.updateDeploymentTemplate(event.document);
-        });
+        this.updateDeploymentTemplate(event.document);
     }
 
     private onDocumentOpened(openedDocument: vscode.TextDocument): void {
-        this.logOnError(() => {
-            this.updateDeploymentTemplate(openedDocument);
-        });
+        this.updateDeploymentTemplate(openedDocument);
     }
 
     private onDocumentSaved(savedDocument: vscode.TextDocument): void {
-        this.logOnError(() => {
+        const me = this;
+        callWithTelemetryAndErrorHandlingSync('onDocumentSaved', function (this: IActionContext) {
+            this.properties.isActivationEvent = 'true';
+            this.suppressTelemetry = true;
+
             // The saved document is a deployment template if it shows up in our deployment
             // templates dictionary.
-            if (this._deploymentTemplates[savedDocument.uri.toString()]) {
-                this.log("Deployment Template Saved", {
-                    autoSave: this._autoSave
+            if (me._deploymentTemplates[savedDocument.uri.toString()]) {
+                ext.reporter.sendTelemetryEvent("Deployment Template Saved", {
+                    autoSave: me._autoSave
                 });
             }
         });
     }
 
     private onDocumentClosed(closedDocument: vscode.TextDocument): void {
-        this.logOnError(() => {
-            this.closeDeploymentTemplate(closedDocument);
+        const me = this;
+        callWithTelemetryAndErrorHandlingSync('onDocumentClosed', function (this: IActionContext) {
+            this.properties.isActivationEvent = 'true';
+            this.suppressTelemetry = true;
+            this.suppressErrorDisplay = true;
+
+            me.closeDeploymentTemplate(closedDocument);
         });
     }
 
     private loadConfiguration(): void {
-        const configuration = vscode.workspace.getConfiguration("azurermtools");
-        this._azureRMToolsConfiguration = {
-            debug: configuration.get("debug", false),
-            enableTelemetry: configuration.get("enableTelemetry", false)
-        };
+        callWithTelemetryAndErrorHandlingSync('loadConfiguration', () => {
+            const configuration = vscode.workspace.getConfiguration("azurermtools");
+            this._azureRMToolsConfiguration = {
+                debug: configuration.get("debug", false),
+                enableTelemetry: configuration.get("enableTelemetry", false)
+            };
 
-        const filesConfiguration = vscode.workspace.getConfiguration("files");
-        this._autoSave = filesConfiguration.get("autoSave", "off");
+            const filesConfiguration = vscode.workspace.getConfiguration("files");
+            this._autoSave = filesConfiguration.get("autoSave", "off");
+        });
     }
 
     private getVSCodeRangeFromSpan(deploymentTemplate: DeploymentTemplate, span: language.Span): vscode.Range {
@@ -750,40 +744,6 @@ export class AzureRMTools {
 
         return new vscode.Range(vscodeStartPosition, vscodeEndPosition);
     }
-
-    private log(
-        eventName: string,
-        properties: TelemetryProperties = {},
-        measures: TelemetryMeasurements = {}
-    ): void {
-        ext.reporter.sendTelemetryEvent(eventName, properties, measures);
-    }
-
-    private logOnError(operation: () => void): void {
-        assert(operation);
-
-        try {
-            operation();
-        } catch (error) {
-            this.logError("UnhandledError", error);
-        }
-    }
-
-    private logError(eventName: string, error: unknown): void {
-        const errorData: IParsedError = parseError(error);
-        let properties: TelemetryProperties = {};
-
-        if (errorData.isUserCancelledError) {
-            properties.result = 'Canceled';
-        } else {
-            properties.result = 'Failed';
-            properties.error = errorData.errorType;
-            properties.errorMessage = errorData.message;
-        }
-
-        ext.reporter.sendTelemetryEvent(eventName, properties);
-    }
-
 }
 
 interface AzureRMToolsConfiguration {

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -111,6 +111,7 @@ export class AzureRMTools {
         const me = this;
         callWithTelemetryAndErrorHandlingSync('dispose', function (this: IActionContext) {
             this.properties.isActivationEvent = 'true';
+            this.suppressErrorDisplay = true;
 
             if (me._deploymentTemplateFileSubscriptions) {
                 me._deploymentTemplateFileSubscriptions.dispose();
@@ -604,7 +605,7 @@ export class AzureRMTools {
         const deploymentTemplate: DeploymentTemplate = this.getDeploymentTemplate(document);
         if (deploymentTemplate) {
             const me = this;
-            return callWithTelemetryAndErrorHandlingSync('Rename', function (this: IActionContext) {
+            return callWithTelemetryAndErrorHandlingSync('Rename', () => {
                 const result: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
 
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
@@ -631,10 +632,7 @@ export class AzureRMTools {
                         result.replace(documentUri, referenceRange, newName);
                     }
                 } else {
-                    const message = 'You can only rename parameters and variables.';
-                    vscode.window.showInformationMessage(message);
-                    this.suppressErrorDisplay = true;
-                    throw new Error(message);
+                    throw new Error('You can only rename parameters and variables.');
                 }
 
                 return result;

--- a/src/DeploymentTemplate.ts
+++ b/src/DeploymentTemplate.ts
@@ -116,8 +116,9 @@ export class DeploymentTemplate {
 
     public get errors(): Promise<language.Issue[]> {
         if (this._errors === undefined) {
-            this._errors = AzureRMAssets.getFunctionsMetadata()
-                .then((functions: FunctionsMetadata) => {
+            this._errors = new Promise<language.Issue[]>(async (resolve, reject) => {
+                try {
+                    let functions: FunctionsMetadata = await AzureRMAssets.getFunctionsMetadata();
                     const parseErrors: language.Issue[] = [];
                     for (const jsonQuotedStringToken of this.jsonQuotedStringTokens) {
                         const jsonTokenStartIndex: number = jsonQuotedStringToken.span.startIndex;
@@ -164,9 +165,13 @@ export class DeploymentTemplate {
                         }
                     }
 
-                    return parseErrors;
-                });
+                    resolve(parseErrors);
+                } catch (err) {
+                    reject(err);
+                }
+            });
         }
+
         return this._errors;
     }
 

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
-// tslint:disable:max-func-body-length
+// tslint:disable:max-func-body-length align
 
 import * as assert from "assert";
 import * as path from "path";
@@ -51,7 +51,7 @@ suite("TreeView", async (): Promise<void> => {
                 assert.equal(!!extension, true, "Extension not found");
                 await extension.activate();
                 provider = ext.jsonOutlineProvider;
-                assert.equal(!!provider, true, "JSON outlin provider not found");
+                assert.equal(!!provider, true, "JSON outline provider not found");
             }
 
             mySetup().then(done, () => { assert.fail("Setup failed"); });
@@ -1519,7 +1519,7 @@ suite("TreeView", async (): Promise<void> => {
                 }                        `;
 
             await testTree(templateNewVM,
-                           [
+                [
                     {
                         label: "$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                         collapsibleState: 0,
@@ -3011,7 +3011,7 @@ suite("TreeView", async (): Promise<void> => {
                 "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                 true: false
             }`,
-                           [
+                [
                     {
                         label: "$schema: https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                         collapsibleState: 0,
@@ -3030,7 +3030,7 @@ suite("TreeView", async (): Promise<void> => {
                     "true: false
                 }
             }`,
-                           [
+                [
                     {
                         label: "$schema: https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                         collapsibleState: 0,


### PR DESCRIPTION
Fixes #166, fixes #115, fixes #38 

The fix for #166 is correcting the path in getLocalAssetUri (removing a ".." to adjust for webpack change).  This error was getting ignored, so the rest of the PR is:
1) Simplifying AzureRMAssets.ts (don't need everything to be calculated on demand) and making sure that errors get carried through
2) Rewriting error handling in AzureRMTools.ts to use callWithTelemetryAndErrorHandling.