### PR TITLE
Reverting PR 183 (newguid and utcnow functions)

### DIFF
--- a/assets/ExpressionMetadata.json
+++ b/assets/ExpressionMetadata.json
@@ -100,13 +100,6 @@
             "maximumArguments": 1
         },
         {
-            "name": "utcNow",
-            "expectedUsage": "utcNow([format])",
-            "description": "Returns the current (UTC) datetime value in the format provided. If no format is provided the ISO 8601 (yyyyMMddTHH:mm:ssZ) format will be used. This function may only be used as a defaultValue on a parameter.",
-            "minimumArguments": 0,
-            "maximumArguments": 1
-        },
-        {
             "name": "deployment",
             "expectedUsage": "deployment()",
             "description": "Returns information about the current deployment operation. This function returns the object that is passed during deployment. The properties in the returned object will differ based on whether the deployment object is passed as a link or as an in-line object.",
@@ -373,13 +366,6 @@
             "description": "Returns the multiplication of the two provided integers.",
             "minimumArguments": 2,
             "maximumArguments": 2
-        },
-        {
-            "name": "newGuid",
-            "expectedUsage": "newGuid()",
-            "description": "Returns a globally unique identifier (GUID). This function may only be used as a defaultValue on a parameter.",
-            "minimumArguments": 0,
-            "maximumArguments": 0
         },
         {
             "name": "not",


### PR DESCRIPTION
Reverting #183 to avoid false positives as their usage is scoped to parameter ->defaultValue 