### PR TITLE
Add source to errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"
             ],
-            "preLaunchTask": "npm: webpack",
+            "preLaunchTask": "npm: pretest-dev",
             "env": {
                 "MOCHA_grep": "", // RegExp of tests to run (empty for all)
                 "MOCHA_enableTimeouts": "0", // Disable time-outs

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lint-fix": "tslint --project tsconfig.json -t verbose --fix",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "npm run build && npm run webpack-prod",
+    "pretest-dev": "npm run build && npm run webpack",
     "test": "gulp test",
     "all": "npm i && npm run lint && npm test",
     "webpack": "gulp webpack-dev",

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -356,7 +356,9 @@ export class AzureRMTools {
     private getVSCodeDiagnosticFromIssue(deploymentTemplate: DeploymentTemplate, issue: language.Issue, severity: vscode.DiagnosticSeverity): vscode.Diagnostic {
         const range: vscode.Range = this.getVSCodeRangeFromSpan(deploymentTemplate, issue.span);
         const message: string = issue.message;
-        return new vscode.Diagnostic(range, message, severity);
+        let diagnostic = new vscode.Diagnostic(range, message, severity);
+        diagnostic.source = 'ARM Tools';
+        return diagnostic;
     }
 
     private closeDeploymentTemplate(document: vscode.TextDocument): void {


### PR DESCRIPTION
... So users can tell where the errors are coming from.

Before:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/6913354/55687698-d5130900-5924-11e9-84d7-50955eac174c.png">
After:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/6913354/55687713-f542c800-5924-11e9-8a02-ca2ec5d0b3c7.png">
