### PR TITLE
Remove unused `AzureRMToolsConfiguration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,7 @@
     "configuration": {
       "type": "object",
       "title": "Azure Resource Manager Tools Configuration Settings",
-      "properties": {
-        "azurermtools.enableTelemetry": {
-          "type": "boolean",
-          "default": true,
-          "description": "Allow anonymous telemetry for the Azure Resource Manager Tools extension."
-        }
-      }
+      "properties": {}
     },
     "views": {
       "explorer": [

--- a/src/AzureRMAssets.ts
+++ b/src/AzureRMAssets.ts
@@ -77,7 +77,6 @@ export class FunctionsMetadata {
     }
 
     public filterByPrefix(functionNamePrefix: string): FunctionMetadata[] {
-        const result: FunctionMetadata[] = [];
         const lowerCasedPrefix: string = functionNamePrefix.toLowerCase();
         return this.functionMetadata.filter(func => func.lowerCaseName.startsWith(lowerCasedPrefix));
     }

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -198,7 +198,8 @@ export class AzureRMTools {
         const me = this;
 
         // Don't wait
-        let dontWait = callWithTelemetryAndErrorHandling('reportDeploymentTemplateErrors', async function (this: IActionContext): Promise<void> {
+        // tslint:disable-next-line: no-floating-promises
+        callWithTelemetryAndErrorHandling('reportDeploymentTemplateErrors', async function (this: IActionContext): Promise<void> {
             this.suppressTelemetry = true;
 
             let parseErrors: language.Issue[] = await deploymentTemplate.errors;
@@ -295,7 +296,8 @@ export class AzureRMTools {
      */
     private logFunctionCounts(deploymentTemplate: DeploymentTemplate): void {
         // Don't wait for promise
-        let dummyPromise = callWithTelemetryAndErrorHandling("tle.stats", async function (this: IActionContext): Promise<void> {
+        // tslint:disable-next-line: no-floating-promises
+        callWithTelemetryAndErrorHandling("tle.stats", async function (this: IActionContext): Promise<void> {
             this.suppressErrorDisplay = true;
             let properties: {
                 functionCounts?: string;

--- a/src/DeploymentTemplate.ts
+++ b/src/DeploymentTemplate.ts
@@ -12,11 +12,10 @@ import * as Reference from "./Reference";
 import * as TLE from "./TLE";
 import * as Utilities from "./Utilities";
 
-import { AzureRMAssets, FunctionMetadata, FunctionsMetadata } from "./AzureRMAssets";
+import { AzureRMAssets, FunctionsMetadata } from "./AzureRMAssets";
 import { Histogram } from "./Histogram";
 import { ParameterDefinition } from "./ParameterDefinition";
 import { PositionContext } from "./PositionContext";
-import { Stopwatch } from "./Stopwatch";
 
 export class DeploymentTemplate {
     private _jsonParseResult: Json.ParseResult;

--- a/src/Hover.ts
+++ b/src/Hover.ts
@@ -24,7 +24,7 @@ export abstract class Info {
  * The information that will be displayed when the cursor hovers over a TLE function.
  */
 export class FunctionInfo extends Info {
-    constructor(private _name: string, private _usage: string, private _description: string, private _functionNameSpan: language.Span) {
+    constructor(private _name: string, private _usage: string, private _description: string, _functionNameSpan: language.Span) {
         super(_functionNameSpan);
     }
 
@@ -41,7 +41,7 @@ export class FunctionInfo extends Info {
  * The information that will be displayed when the cursor hovers over a TLE parameter reference.
  */
 export class ParameterReferenceInfo extends Info {
-    constructor(private _name: string, private _description: string, private _parameterNameSpan: language.Span) {
+    constructor(private _name: string, private _description: string, _parameterNameSpan: language.Span) {
         super(_parameterNameSpan);
     }
 
@@ -54,7 +54,7 @@ export class ParameterReferenceInfo extends Info {
  * The information that will be displayed when the cursor hovers over a TLE variable reference.
  */
 export class VariableReferenceInfo extends Info {
-    constructor(private _name: string, private _variableNameSpan: language.Span) {
+    constructor(private _name: string, _variableNameSpan: language.Span) {
         super(_variableNameSpan);
     }
 

--- a/src/PositionContext.ts
+++ b/src/PositionContext.ts
@@ -25,7 +25,6 @@ export class PositionContext {
     private _jsonToken: Json.Token;
     private _jsonValue: Json.Value;
     private _tleParseResult: TLE.ParseResult;
-    private _tleToken: TLE.Token;
     private _tleValue: TLE.Value;
     private _hoverInfo: Promise<Hover.Info>;
     private _completionItems: Promise<Completion.Item[]>;
@@ -381,16 +380,6 @@ export class PositionContext {
             }
         }
         return this._signatureHelp;
-    }
-
-    private getParametersOrVariablesReplaceSpanInEmptyArgumentList(tleValue: TLE.FunctionValue): language.Span {
-        let replaceSpan: language.Span;
-        if (tleValue.rightParenthesisToken) {
-            replaceSpan = new language.Span(this.documentCharacterIndex, tleValue.rightParenthesisToken.span.startIndex - this.tleCharacterIndex + 1);
-        } else {
-            replaceSpan = this.emptySpanAtDocumentCharacterIndex;
-        }
-        return replaceSpan;
     }
 
     /**

--- a/src/TLE.ts
+++ b/src/TLE.ts
@@ -93,10 +93,6 @@ export class StringValue extends Value {
         return this.toString()[0];
     }
 
-    private get lastCharacter(): string {
-        return this.toString()[this.length - 1];
-    }
-
     public getSpan(): language.Span {
         return this._token.span;
     }
@@ -389,8 +385,6 @@ export class PropertyAccess extends ParentValue {
      */
     public get sourcesNameStack(): string[] {
         const result: string[] = [];
-
-        const propertyAccesses: PropertyAccess[] = [];
 
         let propertyAccessSource: PropertyAccess = asPropertyAccessValue(this._source);
         while (propertyAccessSource) {
@@ -817,7 +811,7 @@ export class FindReferencesVisitor extends Visitor {
     private _references: Reference.List;
     private _lowerCasedName: string;
 
-    constructor(private _kind: Reference.ReferenceKind, private _name: string) {
+    constructor(private _kind: Reference.ReferenceKind, _name: string) {
         super();
 
         this._references = new Reference.List(_kind);

--- a/src/Treeview.ts
+++ b/src/Treeview.ts
@@ -46,13 +46,12 @@ const resourceIcons: [string, string][] = [
 export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
     private tree: Json.ParseResult;
     private text: string;
-    private editor: vscode.TextEditor;
 
     public readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<string | null> =
         new vscode.EventEmitter<string | null>();
     public readonly onDidChangeTreeData: vscode.Event<string | null> = this.onDidChangeTreeDataEmitter.event;
 
-    constructor(private context: vscode.ExtensionContext) {
+    constructor(context: vscode.ExtensionContext) {
         context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(() => this.updateTreeState()));
         context.subscriptions.push(vscode.workspace.onDidChangeTextDocument(() => this.updateTreeState()));
 

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -8,7 +8,7 @@ import * as assert from "assert";
 import * as path from "path";
 import * as vscode from "vscode";
 import { parseError } from "vscode-azureextensionui";
-import { ext, JsonOutlineProvider, shortenTreeLabel, Span } from "../extension.bundle";
+import { ext, JsonOutlineProvider, shortenTreeLabel } from "../extension.bundle";
 
 suite("TreeView", async (): Promise<void> => {
     suite("shortenTreeLabel", async (): Promise<void> => {
@@ -60,7 +60,7 @@ suite("TreeView", async (): Promise<void> => {
         });
 
         async function testChildren(template: string, expected: ITestTreeItem[]): Promise<void> {
-            let editor = await showNewTextDocument(template);
+            await showNewTextDocument(template);
             let rawTree = provider.getChildren(null);
             let tree = rawTree.map(child => {
                 let treeItem = provider.getTreeItem(child);
@@ -72,7 +72,7 @@ suite("TreeView", async (): Promise<void> => {
 
         // Tests the tree against only the given properties
         async function testTree(template: string, expected: ITestTreeItem[], selectProperties?: string[]): Promise<void> {
-            let editor = await showNewTextDocument(template);
+            await showNewTextDocument(template);
             let rawTree = getTree(null);
 
             function select(node: ITestTreeItem): Partial<ITestTreeItem> {
@@ -3067,27 +3067,12 @@ function toTestTreeItem(item: vscode.TreeItem): ITestTreeItem {
     return testItem;
 }
 
-function getTextAtSpan(span: Span): string {
-    return templateAllParamDefaultTypes.substr(span.startIndex, span.length);
-}
-
 async function showNewTextDocument(text: string): Promise<vscode.TextEditor> {
     let textDocument = await vscode.workspace.openTextDocument({
         language: "jsonc",
         content: text
     });
     return await vscode.window.showTextDocument(textDocument);
-}
-
-async function writeToEditor(editor: vscode.TextEditor, data: string): Promise<void> {
-    await editor.edit((editBuilder: vscode.TextEditorEdit) => {
-        if (editor.document.lineCount > 0) {
-            const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
-            editBuilder.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(lastLine.range.start.line, lastLine.range.end.character)));
-        }
-
-        editBuilder.insert(new vscode.Position(0, 0), data);
-    });
 }
 
 const templateAllParamDefaultTypes: string = `

--- a/test/colorization/tle-colorization.test.ts
+++ b/test/colorization/tle-colorization.test.ts
@@ -11,7 +11,7 @@ const OVERWRITE = true;
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import { ISuite, ISuiteCallbackContext } from 'mocha';
+import { ISuiteCallbackContext } from 'mocha';
 import * as os from 'os';
 import * as path from 'path';
 import { commands, Uri } from 'vscode';
@@ -69,7 +69,6 @@ async function assertUnchangedTokens(testPath: string, resultPath: string): Prom
     let data: ITokenInfo[] = rawData.map(d => <ITokenInfo>{ text: d.c.trim(), scopes: d.t, colors: d.r })
         .filter(d => d.text !== "");
     let testCases: ITestcase[];
-    let allDataAsString = data.map((d, i) => `${i}: ${d.text} => ${d.scopes}`).join(os.EOL);
 
     // If the test filename contains ".invalid.", then all testcases in it should have at least one "invalid" token.
     // Otherwise they should contain none.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es6",
         "outDir": "out",
         "noLib": false,
-        "sourceMap": true
+        "sourceMap": true,
+        "noUnusedLocals": true
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
I noticed a spike in telemetry for ARM and the 'loadConfiguration' event was the cause. I went to mark it as an activationEvent, but noticed `_azureRMToolsConfiguration` is never used. In fact, the README already says to use the more standard `telemetry.enableTelemetry` instead of `azurermtools.enableTelemetry`.

In addition, `_autoSave` is only used in `onDocumentSaved`, but I don't think that telemetry event has much value at all. It seems better _not_ to run code on every save just for telemetry.