### PR TITLE
Fix null span in some parse scenarios

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,7 +60,7 @@
             "preLaunchTask": "npm: compile",
             "env": {
                 "AZCODE_IGNORE_BUNDLE": "1",
-                "MOCHA_grep": "color", // RegExp of tests to run (empty for all)
+                "MOCHA_grep": "", // RegExp of tests to run (empty for all)
                 "MOCHA_enableTimeouts": "0", // Disable time-outs
                 "DEBUGTELEMETRY": "1",
                 "NODE_DEBUG": ""

--- a/src/JSON.ts
+++ b/src/JSON.ts
@@ -1067,8 +1067,10 @@ function parseObject(tokenizer: Tokenizer, tokens: Token[]): ObjectValue {
             }
         } else {
             const propertyValue: Value = parseValue(tokenizer, tokens);
-            propertySpan = propertySpan.union(propertyValue.span);
-            objectSpan = objectSpan.union(propertyValue.span);
+            if (propertyValue) {
+                propertySpan = propertySpan.union(propertyValue.span);
+                objectSpan = objectSpan.union(propertyValue.span);
+            }
 
             properties.push(new Property(propertySpan, propertyName, propertyValue));
 

--- a/src/JSON.ts
+++ b/src/JSON.ts
@@ -603,7 +603,7 @@ export class ObjectValue extends Value {
  * A property in a JSON ObjectValue.
  */
 export class Property extends Value {
-    constructor(span: language.Span, private _name: StringValue, private _value: Value) {
+    constructor(span: language.Span, private _name: StringValue, private _value: Value | null) {
         super(span);
     }
 
@@ -621,7 +621,7 @@ export class Property extends Value {
     /**
      * The value of the property.
      */
-    public get value(): Value {
+    public get value(): Value | null {
         return this._value;
     }
 
@@ -992,7 +992,7 @@ export function parse(stringValue: string): ParseResult {
  * All of the Tokens that are read will be placed into the provided
  * tokens array.
  */
-function parseValue(tokenizer: Tokenizer, tokens: Token[]): Value {
+function parseValue(tokenizer: Tokenizer, tokens: Token[]): Value | null {
     let value: Value = null;
 
     if (!tokenizer.hasStarted()) {
@@ -1066,7 +1066,7 @@ function parseObject(tokenizer: Tokenizer, tokens: Token[]): ObjectValue {
                 propertyName = null;
             }
         } else {
-            const propertyValue: Value = parseValue(tokenizer, tokens);
+            const propertyValue: Value | null = parseValue(tokenizer, tokens);
             if (propertyValue) {
                 propertySpan = propertySpan.union(propertyValue.span);
                 objectSpan = objectSpan.union(propertyValue.span);

--- a/test/DeploymentTemplate.test.ts
+++ b/test/DeploymentTemplate.test.ts
@@ -1005,12 +1005,15 @@ suite("Incomplete JSON shouldn't crash parse", () => {
     }
     `;
 
-    test("https://github.com/Microsoft/vscode-azurearmtools/issues/193", () => {
+    test("https://github.com/Microsoft/vscode-azurearmtools/issues/193", async () => {
+        // Just make sure nothing throws
         let modifiedTemplate = template.replace('"type": "string"', '"type": string');
-        new DeploymentTemplate(modifiedTemplate, "id");
+        let dt = new DeploymentTemplate(modifiedTemplate, "id");
+        await dt.errors;
     });
 
     test("typing character by character", async () => {
+        // Just make sure nothing throws
         for (let i = 0; i < template.length; ++i) {
             let partialTemplate = template.slice(0, i);
             let dt = new DeploymentTemplate(partialTemplate, "id");
@@ -1019,6 +1022,7 @@ suite("Incomplete JSON shouldn't crash parse", () => {
     });
 
     test("typing backwards character by character", async () => {
+        // Just make sure nothing throws
         for (let i = 0; i < template.length; ++i) {
             let partialTemplate = template.slice(i);
             let dt = new DeploymentTemplate(partialTemplate, "id");
@@ -1027,6 +1031,7 @@ suite("Incomplete JSON shouldn't crash parse", () => {
     });
 
     test("Random modifications", async () => {
+        // Just make sure nothing throws
         let modifiedTemplate: string = template;
 
         for (let i = 0; i < 1000; ++i) {


### PR DESCRIPTION
Fixes #193, fixes #221 

Parsing is throwing, so the deployment template doesn't get updated from the current text, so the line/column info given to us by vscode can be invalid against our out-of-date stored document text.