### PR TITLE
Completions for deep parameter access

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -414,8 +414,8 @@ export class AzureRMTools {
                 this.suppressErrorDisplay = true;
 
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
-                if (context.completionItems) {
-                    let completionItemArray: Completion.Item[] = await context.completionItems;
+                if (context.getCompletionItems()) {
+                    let completionItemArray: Completion.Item[] = await context.getCompletionItems();
                     const completionItems: vscode.CompletionItem[] = [];
                     for (const completion of completionItemArray) {
                         const insertRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, completion.insertSpan);

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -414,42 +414,40 @@ export class AzureRMTools {
                 this.suppressErrorDisplay = true;
 
                 const context: PositionContext = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
-                if (context.getCompletionItems()) {
-                    let completionItemArray: Completion.Item[] = await context.getCompletionItems();
-                    const completionItems: vscode.CompletionItem[] = [];
-                    for (const completion of completionItemArray) {
-                        const insertRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, completion.insertSpan);
+                let completionItemArray: Completion.Item[] = await context.getCompletionItems();
+                const completionItems: vscode.CompletionItem[] = [];
+                for (const completion of completionItemArray) {
+                    const insertRange: vscode.Range = me.getVSCodeRangeFromSpan(deploymentTemplate, completion.insertSpan);
 
-                        const completionToAdd = new vscode.CompletionItem(completion.name);
-                        completionToAdd.range = insertRange;
-                        completionToAdd.insertText = new vscode.SnippetString(completion.insertText);
-                        completionToAdd.detail = completion.detail;
-                        completionToAdd.documentation = completion.description;
+                    const completionToAdd = new vscode.CompletionItem(completion.name);
+                    completionToAdd.range = insertRange;
+                    completionToAdd.insertText = new vscode.SnippetString(completion.insertText);
+                    completionToAdd.detail = completion.detail;
+                    completionToAdd.documentation = completion.description;
 
-                        switch (completion.kind) {
-                            case Completion.CompletionKind.Function:
-                                completionToAdd.kind = vscode.CompletionItemKind.Function;
-                                break;
+                    switch (completion.kind) {
+                        case Completion.CompletionKind.Function:
+                            completionToAdd.kind = vscode.CompletionItemKind.Function;
+                            break;
 
-                            case Completion.CompletionKind.Parameter:
-                            case Completion.CompletionKind.Variable:
-                                completionToAdd.kind = vscode.CompletionItemKind.Variable;
-                                break;
+                        case Completion.CompletionKind.Parameter:
+                        case Completion.CompletionKind.Variable:
+                            completionToAdd.kind = vscode.CompletionItemKind.Variable;
+                            break;
 
-                            case Completion.CompletionKind.Property:
-                                completionToAdd.kind = vscode.CompletionItemKind.Field;
-                                break;
+                        case Completion.CompletionKind.Property:
+                            completionToAdd.kind = vscode.CompletionItemKind.Field;
+                            break;
 
-                            default:
-                                assert.fail(`Unrecognized Completion.Type: ${completion.kind}`);
-                                break;
-                        }
-                        properties.completionKind = vscode.CompletionItemKind[completionToAdd.kind];
-
-                        completionItems.push(completionToAdd);
+                        default:
+                            assert.fail(`Unrecognized Completion.Type: ${completion.kind}`);
+                            break;
                     }
-                    return new vscode.CompletionList(completionItems, true);
+                    properties.completionKind = vscode.CompletionItemKind[completionToAdd.kind];
+
+                    completionItems.push(completionToAdd);
                 }
+                return new vscode.CompletionList(completionItems, true);
             });
         }
     }

--- a/src/DeploymentTemplate.ts
+++ b/src/DeploymentTemplate.ts
@@ -339,6 +339,19 @@ export class DeploymentTemplate {
         return result;
     }
 
+    public getParameterDefinitionFromFunction(tleFunction: TLE.FunctionValue): ParameterDefinition {
+        let result: ParameterDefinition = null;
+
+        if (tleFunction && tleFunction.nameToken.stringValue === "parameters") {
+            const propertyName: TLE.StringValue = TLE.asStringValue(tleFunction.argumentExpressions[0]);
+            if (propertyName) {
+                result = this.getParameterDefinition(propertyName.toString());
+            }
+        }
+
+        return result;
+    }
+
     public findParameterDefinitionsWithPrefix(parameterNamePrefix: string): ParameterDefinition[] {
         assert(parameterNamePrefix !== null, "parameterNamePrefix cannot be null");
         assert(parameterNamePrefix !== undefined, "parameterNamePrefix cannot be undefined");

--- a/src/ParameterDefinition.ts
+++ b/src/ParameterDefinition.ts
@@ -11,7 +11,8 @@ import * as language from "./Language";
  * This class represents the definition of a parameter in a deployment template.
  */
 export class ParameterDefinition {
-    private _description: string;
+    private _description: string | undefined | null;
+    private _defaultValue: Json.Value | undefined | null;
 
     constructor(private _property: Json.Property) {
         assert(_property);
@@ -41,5 +42,17 @@ export class ParameterDefinition {
             }
         }
         return this._description;
+    }
+
+    public get defaultValue(): Json.Value {
+        if (this._defaultValue === undefined) {
+            this._defaultValue = null;
+
+            const parameterDefinition: Json.ObjectValue = Json.asObjectValue(this._property.value);
+            if (parameterDefinition) {
+                this._defaultValue = parameterDefinition.getPropertyValue("defaultValue");
+            }
+        }
+        return this._defaultValue;
     }
 }

--- a/src/PositionContext.ts
+++ b/src/PositionContext.ts
@@ -27,7 +27,7 @@ export class PositionContext {
     private _tleParseResult: TLE.ParseResult;
     private _tleValue: TLE.Value;
     private _hoverInfo: Promise<Hover.Info>;
-    private _completionItems: Promise<Completion.Item[]>;
+    private _completionItemsPromise: Promise<Completion.Item[]> | undefined;
     private _parameterDefinition: ParameterDefinition;
     private _variableDefinition: Json.Property;
     private _references: Reference.List;
@@ -173,121 +173,123 @@ export class PositionContext {
     }
 
     // tslint:disable-next-line:cyclomatic-complexity max-func-body-length // Grandfathered in
+    // CONSIDER: Needs refactoring
     public async getCompletionItems(): Promise<Completion.Item[]> {
-        if (this._completionItems === undefined) {
-            this._completionItems = Promise.resolve([]);
+        if (!this._completionItemsPromise) {
+            // tslint:disable-next-line:cyclomatic-complexity max-func-body-length // Grandfathered in
+            this._completionItemsPromise = (async () => {
+                if (this.tleParseResult) {
+                    const tleValue: TLE.Value = this.tleValue;
 
-            if (this.tleParseResult) {
-                const tleValue: TLE.Value = this.tleValue;
+                    if (!tleValue || !tleValue.contains(this.tleCharacterIndex)) {
+                        const leftSquareBracketToken: TLE.Token = this.tleParseResult.leftSquareBracketToken;
+                        const rightSquareBracketToken: TLE.Token = this.tleParseResult.rightSquareBracketToken;
 
-                if (!tleValue || !tleValue.contains(this.tleCharacterIndex)) {
-                    const leftSquareBracketToken: TLE.Token = this.tleParseResult.leftSquareBracketToken;
-                    const rightSquareBracketToken: TLE.Token = this.tleParseResult.rightSquareBracketToken;
+                        if (leftSquareBracketToken && leftSquareBracketToken.span.afterEndIndex <= this.tleCharacterIndex &&
+                            (!rightSquareBracketToken || this.tleCharacterIndex <= rightSquareBracketToken.span.startIndex)) {
 
-                    if (leftSquareBracketToken && leftSquareBracketToken.span.afterEndIndex <= this.tleCharacterIndex &&
-                        (!rightSquareBracketToken || this.tleCharacterIndex <= rightSquareBracketToken.span.startIndex)) {
-
-                        this._completionItems = PositionContext.getFunctionCompletions("", this.emptySpanAtDocumentCharacterIndex);
-                    }
-                } else if (tleValue instanceof TLE.FunctionValue) {
-                    if (tleValue.nameToken.span.contains(this.tleCharacterIndex, true)) {
-                        // If the caret is inside the TLE function's name
-                        const functionNameStartIndex: number = tleValue.nameToken.span.startIndex;
-                        const functionNamePrefix: string = tleValue.nameToken.stringValue.substring(0, this.tleCharacterIndex - functionNameStartIndex);
-
-                        let replaceSpan: language.Span;
-                        if (functionNamePrefix.length === 0) {
-                            replaceSpan = this.emptySpanAtDocumentCharacterIndex;
-                        } else {
-                            replaceSpan = tleValue.nameToken.span.translate(this.jsonTokenStartIndex);
+                            return await PositionContext.getFunctionCompletions("", this.emptySpanAtDocumentCharacterIndex);
                         }
+                    } else if (tleValue instanceof TLE.FunctionValue) {
+                        if (tleValue.nameToken.span.contains(this.tleCharacterIndex, true)) {
+                            // If the caret is inside the TLE function's name
+                            const functionNameStartIndex: number = tleValue.nameToken.span.startIndex;
+                            const functionNamePrefix: string = tleValue.nameToken.stringValue.substring(0, this.tleCharacterIndex - functionNameStartIndex);
 
-                        this._completionItems = PositionContext.getFunctionCompletions(functionNamePrefix, replaceSpan);
-                    } else if (tleValue.leftParenthesisToken && this.tleCharacterIndex <= tleValue.leftParenthesisToken.span.startIndex) {
-                        // The caret is between the function name and the left parenthesis
-                        this._completionItems = PositionContext.getFunctionCompletions("", this.emptySpanAtDocumentCharacterIndex);
-                    } else {
-                        if (tleValue.nameToken.stringValue === "parameters" && tleValue.argumentExpressions.length === 0) {
-                            this._completionItems = Promise.resolve(this.getParameterCompletions("", tleValue));
-                        } else if (tleValue.nameToken.stringValue === "variables" && tleValue.argumentExpressions.length === 0) {
-                            this._completionItems = Promise.resolve(this.getVariableCompletions("", tleValue));
-                        } else {
-                            this._completionItems = PositionContext.getFunctionCompletions("", this.emptySpanAtDocumentCharacterIndex);
-                        }
-                    }
-                } else if (tleValue instanceof TLE.StringValue) {
-                    // Start at index 1 to skip past the opening single-quote.
-                    const prefix: string = tleValue.toString().substring(1, this.tleCharacterIndex - tleValue.getSpan().startIndex);
-
-                    if (tleValue.isParametersArgument()) {
-                        this._completionItems = Promise.resolve(this.getParameterCompletions(prefix, tleValue));
-                    } else if (tleValue.isVariablesArgument()) {
-                        this._completionItems = Promise.resolve(this.getVariableCompletions(prefix, tleValue));
-                    }
-                } else if (tleValue instanceof TLE.PropertyAccess) {
-                    // Handle completions for property accesses, e.g. "resourceGroup().prop1.prop2"
-                    const functionSource: TLE.FunctionValue = tleValue.functionSource;
-                    if (functionSource) {
-
-                        let propertyPrefix: string = "";
-                        let replaceSpan: language.Span = this.emptySpanAtDocumentCharacterIndex;
-                        const propertyNameToken: TLE.Token = tleValue.nameToken;
-                        if (propertyNameToken) {
-                            replaceSpan = propertyNameToken.span.translate(this.jsonTokenStartIndex);
-                            propertyPrefix = propertyNameToken.stringValue.substring(0, this.tleCharacterIndex - propertyNameToken.span.startIndex).toLowerCase();
-                        }
-
-                        const variableProperty: Json.Property = this._deploymentTemplate.getVariableDefinitionFromFunction(functionSource);
-                        const parameterProperty: ParameterDefinition = this._deploymentTemplate.getParameterDefinitionFromFunction(functionSource);
-                        const sourcesNameStack: string[] = tleValue.sourcesNameStack;
-                        if (variableProperty) {
-                            // If the variable's value is an object...
-                            const sourceVariableDefinition: Json.ObjectValue = Json.asObjectValue(variableProperty.value);
-                            if (sourceVariableDefinition) {
-                                this._completionItems = Promise.resolve(this.getDeepPropertyAccessCompletions(
-                                    propertyPrefix,
-                                    sourceVariableDefinition,
-                                    sourcesNameStack,
-                                    replaceSpan));
+                            let replaceSpan: language.Span;
+                            if (functionNamePrefix.length === 0) {
+                                replaceSpan = this.emptySpanAtDocumentCharacterIndex;
+                            } else {
+                                replaceSpan = tleValue.nameToken.span.translate(this.jsonTokenStartIndex);
                             }
-                        } else if (parameterProperty) {
-                            // If the parameters's default value is an object...
-                            const parameterDefValue: Json.ObjectValue = parameterProperty.defaultValue ? Json.asObjectValue(parameterProperty.defaultValue) : null;
-                            if (parameterDefValue) {
-                                const sourcePropertyDefinition: Json.ObjectValue = Json.asObjectValue(parameterDefValue.getPropertyValueFromStack(sourcesNameStack));
-                                if (sourcePropertyDefinition) {
-                                    this._completionItems = Promise.resolve(this.getDeepPropertyAccessCompletions(
+
+                            return await PositionContext.getFunctionCompletions(functionNamePrefix, replaceSpan);
+                        } else if (tleValue.leftParenthesisToken && this.tleCharacterIndex <= tleValue.leftParenthesisToken.span.startIndex) {
+                            // The caret is between the function name and the left parenthesis (with whitespace between them)
+                            return await PositionContext.getFunctionCompletions("", this.emptySpanAtDocumentCharacterIndex);
+                        } else {
+                            if (tleValue.nameToken.stringValue === "parameters" && tleValue.argumentExpressions.length === 0) {
+                                return this.getParameterCompletions("", tleValue);
+                            } else if (tleValue.nameToken.stringValue === "variables" && tleValue.argumentExpressions.length === 0) {
+                                return this.getVariableCompletions("", tleValue);
+                            } else {
+                                return await PositionContext.getFunctionCompletions("", this.emptySpanAtDocumentCharacterIndex);
+                            }
+                        }
+                    } else if (tleValue instanceof TLE.StringValue) {
+                        // Start at index 1 to skip past the opening single-quote.
+                        const prefix: string = tleValue.toString().substring(1, this.tleCharacterIndex - tleValue.getSpan().startIndex);
+
+                        if (tleValue.isParametersArgument()) {
+                            return this.getParameterCompletions(prefix, tleValue);
+                        } else if (tleValue.isVariablesArgument()) {
+                            return this.getVariableCompletions(prefix, tleValue);
+                        }
+                    } else if (tleValue instanceof TLE.PropertyAccess) {
+                        // Handle completions for property accesses, e.g. "resourceGroup().prop1.prop2"
+                        const functionSource: TLE.FunctionValue = tleValue.functionSource;
+                        if (functionSource) {
+
+                            let propertyPrefix: string = "";
+                            let replaceSpan: language.Span = this.emptySpanAtDocumentCharacterIndex;
+                            const propertyNameToken: TLE.Token = tleValue.nameToken;
+                            if (propertyNameToken) {
+                                replaceSpan = propertyNameToken.span.translate(this.jsonTokenStartIndex);
+                                propertyPrefix = propertyNameToken.stringValue.substring(0, this.tleCharacterIndex - propertyNameToken.span.startIndex).toLowerCase();
+                            }
+
+                            const variableProperty: Json.Property = this._deploymentTemplate.getVariableDefinitionFromFunction(functionSource);
+                            const parameterProperty: ParameterDefinition = this._deploymentTemplate.getParameterDefinitionFromFunction(functionSource);
+                            const sourcesNameStack: string[] = tleValue.sourcesNameStack;
+                            if (variableProperty) {
+                                // If the variable's value is an object...
+                                const sourceVariableDefinition: Json.ObjectValue = Json.asObjectValue(variableProperty.value);
+                                if (sourceVariableDefinition) {
+                                    return this.getDeepPropertyAccessCompletions(
                                         propertyPrefix,
-                                        sourcePropertyDefinition,
+                                        sourceVariableDefinition,
                                         sourcesNameStack,
-                                        replaceSpan));
+                                        replaceSpan);
                                 }
-                            }
-                        } else if (sourcesNameStack.length === 0) {
-                            // We don't allow multiple levels of property access
-                            // (resourceGroup().prop1.prop2) on functions other than variables/parameters,
-                            // therefore checking that sourcesNameStack.length === 0
-                            const functionName: string = functionSource.nameToken.stringValue;
-                            let functionMetadataMatches: FunctionMetadata[] = await AzureRMAssets.getFunctionMetadataFromPrefix(functionName);
-
-                            const result: Completion.Item[] = [];
-                            if (functionMetadataMatches && functionMetadataMatches.length === 1) {
-                                const functionMetadata: FunctionMetadata = functionMetadataMatches[0];
-                                for (const returnValueMember of functionMetadata.returnValueMembers) {
-                                    if (propertyPrefix === "" || returnValueMember.toLowerCase().startsWith(propertyPrefix)) {
-                                        result.push(PositionContext.createPropertyCompletionItem(returnValueMember, replaceSpan));
+                            } else if (parameterProperty) {
+                                // If the parameters's default value is an object...
+                                const parameterDefValue: Json.ObjectValue = parameterProperty.defaultValue ? Json.asObjectValue(parameterProperty.defaultValue) : null;
+                                if (parameterDefValue) {
+                                    const sourcePropertyDefinition: Json.ObjectValue = Json.asObjectValue(parameterDefValue.getPropertyValueFromStack(sourcesNameStack));
+                                    if (sourcePropertyDefinition) {
+                                        return this.getDeepPropertyAccessCompletions(
+                                            propertyPrefix,
+                                            sourcePropertyDefinition,
+                                            sourcesNameStack,
+                                            replaceSpan);
                                     }
                                 }
-                            }
+                            } else if (sourcesNameStack.length === 0) {
+                                // We don't allow multiple levels of property access
+                                // (resourceGroup().prop1.prop2) on functions other than variables/parameters,
+                                // therefore checking that sourcesNameStack.length === 0
+                                const functionName: string = functionSource.nameToken.stringValue;
+                                let functionMetadataMatches: FunctionMetadata[] = await AzureRMAssets.getFunctionMetadataFromPrefix(functionName);
 
-                            this._completionItems = Promise.resolve(result);
+                                const result: Completion.Item[] = [];
+                                if (functionMetadataMatches && functionMetadataMatches.length === 1) {
+                                    const functionMetadata: FunctionMetadata = functionMetadataMatches[0];
+                                    for (const returnValueMember of functionMetadata.returnValueMembers) {
+                                        if (propertyPrefix === "" || returnValueMember.toLowerCase().startsWith(propertyPrefix)) {
+                                            result.push(PositionContext.createPropertyCompletionItem(returnValueMember, replaceSpan));
+                                        }
+                                    }
+                                }
+
+                                return result;
+                            }
                         }
                     }
                 }
-            }
+            })();
         }
 
-        return this._completionItems;
+        return this._completionItemsPromise;
     }
 
     private getDeepPropertyAccessCompletions(propertyPrefix: string, variableOrParameterDefinition: Json.ObjectValue, sourcesNameStack: string[], replaceSpan: language.Span): Completion.Item[] {

--- a/src/PositionContext.ts
+++ b/src/PositionContext.ts
@@ -286,6 +286,8 @@ export class PositionContext {
                         }
                     }
                 }
+
+                return [];
             })();
         }
 

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -464,7 +464,14 @@ suite("PositionContext", () => {
 
                 const dt = new DeploymentTemplate(documentText, "id");
                 const pc: PositionContext = dt.getContextFromDocumentCharacterIndex(index);
-                const completionItems: Completion.Item[] = await pc.getCompletionItems();
+
+                // Verify no race conditions - call twice before awaiting
+                const completionItemsPromise: Promise<Completion.Item[]> = pc.getCompletionItems();
+                const completionItems2Promise: Promise<Completion.Item[]> = pc.getCompletionItems();
+
+                let completionItems: Completion.Item[] = await completionItemsPromise;
+                const completionItems2: Completion.Item[] = await completionItems2Promise;
+                assert.deepStrictEqual(completionItems, completionItems2, "Race condition? Got different results");
 
                 // // tslint:disable-next-line:no-console
                 // console.log("");

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -451,14 +451,29 @@ suite("PositionContext", () => {
         });
     });
 
-    suite("completionItems", () => {
+    suite("completionItems", async () => {
+        function addCursor(documentText: string, markerIndex: number): string {
+            return `${documentText.slice(0, markerIndex)}<CURSOR>${documentText.slice(markerIndex)}`;
+        }
+
         function completionItemsTest(documentText: string, index: number, expectedCompletionItems: Completion.Item[]): void {
-            test(`with ${Utilities.escapeAndQuote(documentText)} at index ${index}`, () => {
+            const testName = `with ${Utilities.escapeAndQuote(addCursor(documentText, index))} at index ${index}`;
+            test(testName, async () => {
+                let keepInClosureForEasierDebugging = testName;
+                keepInClosureForEasierDebugging = keepInClosureForEasierDebugging;
+
                 const dt = new DeploymentTemplate(documentText, "id");
                 const pc: PositionContext = dt.getContextFromDocumentCharacterIndex(index);
-                return pc.getCompletionItems().then((completionItems: Completion.Item[]) => {
-                    compareTestableCompletionItems(completionItems, expectedCompletionItems);
-                });
+                const completionItems: Completion.Item[] = await pc.getCompletionItems();
+
+                // // tslint:disable-next-line:no-console
+                // console.log("");
+                // // tslint:disable-next-line:no-console
+                // console.log(documentText.slice(index - 20, index));
+                // // tslint:disable-next-line:no-console
+                // console.log(completionItems);
+
+                compareTestableCompletionItems(completionItems, expectedCompletionItems);
             });
         }
 
@@ -1084,97 +1099,154 @@ suite("PositionContext", () => {
                                             []);
             }
 
-            for (let i = 0; i <= 28; ++i) {
-                completionItemsTest(`{ "b": "[variables('a').]" }`, i,
-                    (i === 9) ? allCompletions(9, 0) :
-                        (10 <= i && i <= 18) ? [variablesCompletion(9, 9)] :
-                            []);
-            }
-
-            for (let i = 0; i <= 55; ++i) {
-                completionItemsTest(`{ "variables": { "a": "A" }, "b": "[variables('a').]" }`, i,
-                    (i === 36) ? allCompletions(36, 0) :
-                        (37 <= i && i <= 45) ? [variablesCompletion(36, 9)] :
-                            (47 <= i && i <= 48) ? [variableCompletion("a", 46, 4)] :
+            suite("Variable value deep completion for objects", () => {
+                for (let i = 0; i <= 28; ++i) {
+                    completionItemsTest(`{ "b": "[variables('a').]" }`, i,
+                        (i === 9) ? allCompletions(9, 0) :
+                            (10 <= i && i <= 18) ? [variablesCompletion(9, 9)] :
                                 []);
-            }
+                }
 
-            for (let i = 0; i <= 55; ++i) {
-                completionItemsTest(`{ "variables": { "a": 123 }, "b": "[variables('a').]" }`, i,
-                    (i === 36) ? allCompletions(36, 0) :
-                        (37 <= i && i <= 45) ? [variablesCompletion(36, 9)] :
-                            (47 <= i && i <= 48) ? [variableCompletion("a", 46, 4)] :
-                                []);
-            }
-
-            for (let i = 0; i <= 56; ++i) {
-                completionItemsTest(`{ "variables": { "a": true }, "b": "[variables('a').]" }`, i,
-                    (i === 37) ? allCompletions(37, 0) :
-                        (38 <= i && i <= 46) ? [variablesCompletion(37, 9)] :
-                            (48 <= i && i <= 49) ? [variableCompletion("a", 47, 4)] :
-                                []);
-            }
-
-            for (let i = 0; i <= 56; ++i) {
-                completionItemsTest(`{ "variables": { "a": null }, "b": "[variables('a').]" }`, i,
-                    (i === 37) ? allCompletions(37, 0) :
-                        (38 <= i && i <= 46) ? [variablesCompletion(37, 9)] :
-                            (48 <= i && i <= 49) ? [variableCompletion("a", 47, 4)] :
-                                []);
-            }
-
-            for (let i = 0; i <= 54; ++i) {
-                completionItemsTest(`{ "variables": { "a": [] }, "b": "[variables('a').]" }`, i,
-                    (i === 35) ? allCompletions(35, 0) :
-                        (36 <= i && i <= 44) ? [variablesCompletion(35, 9)] :
-                            (46 <= i && i <= 47) ? [variableCompletion("a", 45, 4)] :
-                                []);
-            }
-
-            for (let i = 0; i <= 54; ++i) {
-                completionItemsTest(`{ "variables": { "a": {} }, "b": "[variables('a').]" }`, i,
-                    (i === 35) ? allCompletions(35, 0) :
-                        (36 <= i && i <= 44) ? [variablesCompletion(35, 9)] :
-                            (46 <= i && i <= 47) ? [variableCompletion("a", 45, 4)] :
-                                []);
-            }
-
-            for (let i = 0; i <= 67; ++i) {
-                completionItemsTest(`{ "variables": { "a": { "name": "A" } }, "b": "[variables('a').]" }`, i,
-                    (i === 48) ? allCompletions(48, 0) :
-                        (49 <= i && i <= 57) ? [variablesCompletion(48, 9)] :
-                            (59 <= i && i <= 60) ? [variableCompletion("a", 58, 4)] :
-                                (62 <= i && i <= 63) ? [propertyCompletion("name", i, 0)] :
+                for (let i = 0; i <= 55; ++i) {
+                    completionItemsTest(`{ "variables": { "a": "A" }, "b": "[variables('a').]" }`, i,
+                        (i === 36) ? allCompletions(36, 0) :
+                            (37 <= i && i <= 45) ? [variablesCompletion(36, 9)] :
+                                (47 <= i && i <= 48) ? [variableCompletion("a", 46, 4)] :
                                     []);
-            }
+                }
 
-            for (let i = 0; i <= 69; ++i) {
-                completionItemsTest(`{ "variables": { "a": { "name": "A" } }, "b": "[variables('a').na]" }`, i,
-                    (i === 48) ? allCompletions(48, 0) :
-                        (49 <= i && i <= 57) ? [variablesCompletion(48, 9)] :
-                            (59 <= i && i <= 60) ? [variableCompletion("a", 58, 4)] :
-                                (62 <= i && i <= 65) ? [propertyCompletion("name", 63, 2)] :
+                for (let i = 0; i <= 55; ++i) {
+                    completionItemsTest(`{ "variables": { "a": 123 }, "b": "[variables('a').]" }`, i,
+                        (i === 36) ? allCompletions(36, 0) :
+                            (37 <= i && i <= 45) ? [variablesCompletion(36, 9)] :
+                                (47 <= i && i <= 48) ? [variableCompletion("a", 46, 4)] :
                                     []);
-            }
+                }
 
-            for (let i = 0; i <= 69; ++i) {
-                completionItemsTest(`{ "variables": { "a": { "name": "A" } }, "b": "[variables('a').ab]" }`, i,
-                    (i === 48) ? allCompletions(48, 0) :
-                        (49 <= i && i <= 57) ? [variablesCompletion(48, 9)] :
-                            (59 <= i && i <= 60) ? [variableCompletion("a", 58, 4)] :
-                                (62 <= i && i <= 63) ? [propertyCompletion("name", 63, 2)] :
+                for (let i = 0; i <= 56; ++i) {
+                    completionItemsTest(`{ "variables": { "a": true }, "b": "[variables('a').]" }`, i,
+                        (i === 37) ? allCompletions(37, 0) :
+                            (38 <= i && i <= 46) ? [variablesCompletion(37, 9)] :
+                                (48 <= i && i <= 49) ? [variableCompletion("a", 47, 4)] :
                                     []);
-            }
+                }
 
-            for (let i = 0; i <= 78; ++i) {
-                completionItemsTest(`{ "variables": { "a": { "bb": { "cc": 200 } } }, "b": "[variables('a').bb.]" }`, i,
-                    (i === 56) ? allCompletions(56, 0) :
-                        (57 <= i && i <= 65) ? [variablesCompletion(56, 9)] :
-                            (67 <= i && i <= 68) ? [variableCompletion("a", 66, 4)] :
-                                (70 <= i && i <= 73) ? [propertyCompletion("bb", 71, 2)] :
-                                    (i === 74) ? [propertyCompletion("cc", 74, 0)] :
+                for (let i = 0; i <= 56; ++i) {
+                    completionItemsTest(`{ "variables": { "a": null }, "b": "[variables('a').]" }`, i,
+                        (i === 37) ? allCompletions(37, 0) :
+                            (38 <= i && i <= 46) ? [variablesCompletion(37, 9)] :
+                                (48 <= i && i <= 49) ? [variableCompletion("a", 47, 4)] :
+                                    []);
+                }
+
+                for (let i = 0; i <= 54; ++i) {
+                    completionItemsTest(`{ "variables": { "a": [] }, "b": "[variables('a').]" }`, i,
+                        (i === 35) ? allCompletions(35, 0) :
+                            (36 <= i && i <= 44) ? [variablesCompletion(35, 9)] :
+                                (46 <= i && i <= 47) ? [variableCompletion("a", 45, 4)] :
+                                    []);
+                }
+
+                for (let i = 0; i <= 54; ++i) {
+                    completionItemsTest(`{ "variables": { "a": {} }, "b": "[variables('a').]" }`, i,
+                        (i === 35) ? allCompletions(35, 0) :
+                            (36 <= i && i <= 44) ? [variablesCompletion(35, 9)] :
+                                (46 <= i && i <= 47) ? [variableCompletion("a", 45, 4)] :
+                                    []);
+                }
+
+                for (let i = 0; i <= 67; ++i) {
+                    completionItemsTest(`{ "variables": { "a": { "name": "A" } }, "b": "[variables('a').]" }`, i,
+                        (i === 48) ? allCompletions(48, 0) :
+                            (49 <= i && i <= 57) ? [variablesCompletion(48, 9)] :
+                                (59 <= i && i <= 60) ? [variableCompletion("a", 58, 4)] :
+                                    (62 <= i && i <= 63) ? [propertyCompletion("name", i, 0)] :
                                         []);
+                }
+
+                for (let i = 0; i <= 69; ++i) {
+                    completionItemsTest(`{ "variables": { "a": { "name": "A" } }, "b": "[variables('a').na]" }`, i,
+                        (i === 48) ? allCompletions(48, 0) :
+                            (49 <= i && i <= 57) ? [variablesCompletion(48, 9)] :
+                                (59 <= i && i <= 60) ? [variableCompletion("a", 58, 4)] :
+                                    (62 <= i && i <= 65) ? [propertyCompletion("name", 63, 2)] :
+                                        []);
+                }
+
+                for (let i = 0; i <= 69; ++i) {
+                    completionItemsTest(`{ "variables": { "a": { "name": "A" } }, "b": "[variables('a').ab]" }`, i,
+                        (i === 48) ? allCompletions(48, 0) :
+                            (49 <= i && i <= 57) ? [variablesCompletion(48, 9)] :
+                                (59 <= i && i <= 60) ? [variableCompletion("a", 58, 4)] :
+                                    (62 <= i && i <= 63) ? [propertyCompletion("name", 63, 2)] :
+                                        []);
+                }
+
+                for (let i = 0; i <= 78; ++i) {
+                    completionItemsTest(`{ "variables": { "a": { "bb": { "cc": 200 } } }, "b": "[variables('a').bb.]" }`, i,
+                        (i === 56) ? allCompletions(56, 0) :
+                            (57 <= i && i <= 65) ? [variablesCompletion(56, 9)] :
+                                (67 <= i && i <= 68) ? [variableCompletion("a", 66, 4)] :
+                                    (70 <= i && i <= 73) ? [propertyCompletion("bb", 71, 2)] :
+                                        (i === 74) ? [propertyCompletion("cc", 74, 0)] :
+                                            []);
+                }
+
+            });
+
+            function getDocumentAndMarkers(document: object | string): { documentText: string; tokens: number[] } {
+                let tokens: number[] = [];
+                document = typeof document === "string" ? document : JSON.stringify(document);
+
+                // tslint:disable-next-line:no-constant-condition
+                while (true) {
+                    let tokenPos = document.indexOf("!");
+                    if (tokenPos < 0) {
+                        break;
+                    }
+                    tokens.push(tokenPos);
+                    document = document.slice(0, tokenPos) + document.slice(tokenPos + 1);
+                }
+
+                return {
+                    documentText: document,
+                    tokens
+                };
             }
+
+            suite("Parameter defaultValue deep completion for objects", () => {
+                let { documentText, tokens } = getDocumentAndMarkers({
+                    parameters: {
+                        a: {
+                            type: "object",
+                            defaultValue: {
+                                aa: {
+                                    bb: {
+                                        cc: 200
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    variables: {
+                        b: "[parameters('a').!aa.!bb.!]"
+                    }
+                });
+                let [dotAa, dotBb, dot] = tokens;
+
+                completionItemsTest(
+                    documentText,
+                    dotAa,
+                    [propertyCompletion("aa", dotAa, 2)]);
+                completionItemsTest(
+                    documentText,
+                    dotBb,
+                    [propertyCompletion("bb", dotBb, 2)]);
+                completionItemsTest(
+                    documentText,
+                    dot,
+                    [propertyCompletion("cc", dot, 0)]);
+            });
         }
     });
 

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -474,13 +474,6 @@ suite("PositionContext", () => {
                 assert(!!completionItems);
                 assert.deepStrictEqual(completionItems, completionItems2, "Race condition? Got different results");
 
-                // // tslint:disable-next-line:no-console
-                // console.log("");
-                // // tslint:disable-next-line:no-console
-                // console.log(documentText.slice(index - 20, index));
-                // // tslint:disable-next-line:no-console
-                // console.log(completionItems);
-
                 compareTestableCompletionItems(completionItems, expectedCompletionItems);
             });
         }

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -471,6 +471,7 @@ suite("PositionContext", () => {
 
                 let completionItems: Completion.Item[] = await completionItemsPromise;
                 const completionItems2: Completion.Item[] = await completionItems2Promise;
+                assert(!!completionItems);
                 assert.deepStrictEqual(completionItems, completionItems2, "Race condition? Got different results");
 
                 // // tslint:disable-next-line:no-console

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -456,7 +456,7 @@ suite("PositionContext", () => {
             test(`with ${Utilities.escapeAndQuote(documentText)} at index ${index}`, () => {
                 const dt = new DeploymentTemplate(documentText, "id");
                 const pc: PositionContext = dt.getContextFromDocumentCharacterIndex(index);
-                return pc.completionItems.then((completionItems: Completion.Item[]) => {
+                return pc.getCompletionItems().then((completionItems: Completion.Item[]) => {
                     compareTestableCompletionItems(completionItems, expectedCompletionItems);
                 });
             });


### PR DESCRIPTION
Fixes #124 

This functionality already exists for variables that are of type object, this adds it for properties with a defaultValue of an object type.  

Example:
{
"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
"contentVersion": "1.0.0.0",
"variables": {
"abc": {
"one": 1,
"two": {
"three": 2
}
},
"v1": "[variables('abc').two.three]",
"v2": "[parameters('def')]"
},
"parameters": {
"def": {
"type": "object",
"defaultValue": {
"one": 1,
"two": {
"three": 2
}
}
}
},
"resources": [],
"outputs": {
"a": {
"type": "string",
"value": "[concat(variables('v1'),variables('v2'))]"
}
}
<img width="703" alt="image" src="https://user-images.githubusercontent.com/6913354/57171974-d40fb300-6dce-11e9-9032-7d8b569d5972.png">
