### PR TITLE
Fix case-insensitivity of parameters and variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,7 +299,7 @@ dist
 test-results.xml
 
 # Colorization test failure diffs
-test/*.actual
+test/**/*.actual
 test/**/*.full-scope-result.txt
 
 # Nuget package downloads

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,7 +60,7 @@
             ],
             "preLaunchTask": "npm: compile",
             "env": {
-                "MOCHA_grep": "", // RegExp of tests to run (empty for all)
+                "MOCHA_grep": "olorization", // RegExp of tests to run (empty for all)
                 "AZCODE_ARM_IGNORE_BUNDLE": "1",
                 "MOCHA_enableTimeouts": "0", // Disable time-outs
                 "DEBUGTELEMETRY": "1", // 1=quiet, verbose=see telemetry in console

--- a/grammars/arm-expression-string.tmLanguage.json
+++ b/grammars/arm-expression-string.tmLanguage.json
@@ -22,8 +22,10 @@
 		"scope-builtin": "support.function.builtin.tle.arm-template",
 		"scope-logical": "keyword.control.logical.tle.arm-template",
 		"scope-parameters": "support.type.parameters.tle.arm-template",
+		"$scope-parameter": "The parameter name (including single quotes surrounding it) when it's the immediate argument of a parameters('xxx') expression",
 		"scope-parameter": "support.type.parameters.parameter-name.tle.arm-template",
 		"scope-variables": "variable.language.variables.tle.arm-template",
+		"$scope-variable": "The variable name (including single quotes surrounding it) when it's the immediate argument of a variables('xxx') expression",
 		"scope-variable": "variable.language.variables.variable-name.tle.arm-template",
 		"scope-unknownfunction": "meta.unrecognized-identifier.tle.arm-template",
 		"scope-usernamespace": "entity.name.tag.usernamespace.tle.arm-template",
@@ -150,7 +152,7 @@
 			"$comment1": "When we have 'parameters' with a string literal (instead of an expression), we want to colorize the parameter name along with 'parameters'",
 			"$comment2": "When its parameter is an expression, it will be handled by functionname/functioncall",
 			"name": "meta.parameters-reference.tle.arm-template",
-			"match": "(?x) \\s* (parameters) \\s* (\\() \\s* (' [^']* ') \\s* (\\))",
+			"match": "(?x) \\s* ((?i)parameters) \\s* (\\() \\s* (' [^']* ') \\s* (\\))",
 			"captures": {
 				"1": {
 					"$comment": "parameters",
@@ -174,7 +176,7 @@
 			"$comment1": "When we have 'variables' with a string literal (instead of an expression), we want to colorize the variable name along with 'variables'",
 			"$comment2": "When its parameter is an expression, it will be handled by functionname/functioncall",
 			"name": "meta.variables-reference.tle.arm-template",
-			"match": "(?x) \\s* (variables) \\s* (\\() \\s* (' [^']* ') \\s* (\\))",
+			"match": "(?x) \\s* ((?i)variables) \\s* (\\() \\s* (' [^']* ') \\s* (\\))",
 			"captures": {
 				"1": {
 					"$comment": "variables",
@@ -195,7 +197,7 @@
 			}
 		},
 		"functionname": {
-			"match": "(?x) \\s* (?: {{ns-userfunc}} | (parameters) | (variables) | ({{logical}}) | ({{builtin-functions}}) | ({{id}}) ) (?!{{idchar}} (?# Make sure we don't match a well-known name like 'add' inside something like 'add2'))",
+			"match": "(?x)(?i) \\s* (?: {{ns-userfunc}} | (parameters) | (variables) | ({{logical}}) | ({{builtin-functions}}) | ({{id}}) ) (?!{{idchar}} (?# Make sure we don't match a well-known name like 'add' inside something like 'add2'))",
 			"captures": {
 				"1": {
 					"$comment": "user namespace (capturing group inside ns-userfunc)",

--- a/test/colorization/inputs/functions-case-insensitive.jsonc
+++ b/test/colorization/inputs/functions-case-insensitive.jsonc
@@ -1,11 +1,17 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     // Variables
+    "$TEST": "[variables('a')]",
     "$TEST": "[VARIables('a')]",
     // Parameters
+    "$TEST": "[ parameters ( 'b' ) ]",
     "$TEST": "[ paraMETErs ( 'b' ) ]",
     // User function
     "$TEST": "[my.Parameters('c')]",
-    // Built-in function
-    "$TEST": "[mAX(1)]"
+    // Built-in functions
+    "$TEST": "[max(1)]",
+    "$TEST": "[mAX(1)]",
+    // Logical functions
+    "$TEST": "[and(1,1)]",
+    "$TEST": "[aNd(1,1)]",
 }

--- a/test/colorization/inputs/parameters.jsonc
+++ b/test/colorization/inputs/parameters.jsonc
@@ -1,9 +1,9 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-    
     // With string literal - all same color (except parens)
     "$TEST1": "[parameters('myparam')]",
-
+    "$TEST2": "[Parameters('myparam')]",
     // With expression - normal expression colors inside 'parameters'
-    "$TEST2": "[parameters(concat('myparam', 'a'))]"
+    "$TEST3": "[parameters(concat('myparam', 'a'))]",
+    "$TEST4": "[Parameters(concat('myparam', 'a'))]"
 }

--- a/test/colorization/inputs/variables.jsonc
+++ b/test/colorization/inputs/variables.jsonc
@@ -1,9 +1,9 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-    
     // With string literal - all same color (except parens)
     "$TEST1": "[variables('myvar')]",
-
+    "$TEST1": "[Variables('Myvar')]",
     // With expression - normal expression colors inside 'variables'
-    "$TEST2": "[variables(concat('myvar', 'a'))]"
+    "$TEST2": "[variables(concat('myvar', 'a'))]",
+    "$TEST2": "[Variables(concat('myvar', 'a'))]"
 }

--- a/test/colorization/results/functions-case-insensitive.jsonc.txt
+++ b/test/colorization/results/functions-case-insensitive.jsonc.txt
@@ -1,20 +1,32 @@
+TEST STRING: "[variables('a')]"
+"[                  {{scope-expression-start}}
+variables           {{scope-variables}}
+(                   {{scope-parentheses-funccall}}
+'a'                 {{scope-variable}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
 TEST STRING: "[VARIables('a')]"
 "[                  {{scope-expression-start}}
-VARIables           {{scope-builtin}}
+VARIables           {{scope-variables}}
 (                   {{scope-parentheses-funccall}}
-'                   {{scope-string-start}}
-a                   {{scope-string-contents}}
-'                   {{scope-string-end}}
+'a'                 {{scope-variable}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
+TEST STRING: "[parameters('b')]"
+"[                  {{scope-expression-start}}
+parameters          {{scope-parameters}}
+(                   {{scope-parentheses-funccall}}
+'b'                 {{scope-parameter}}
 )                   {{scope-parentheses-funccall}}
 ]"                  {{scope-expression-end}}
 
 TEST STRING: "[paraMETErs('b')]"
 "[                  {{scope-expression-start}}
-paraMETErs          {{scope-builtin}}
+paraMETErs          {{scope-parameters}}
 (                   {{scope-parentheses-funccall}}
-'                   {{scope-string-start}}
-b                   {{scope-string-contents}}
-'                   {{scope-string-end}}
+'b'                 {{scope-parameter}}
 )                   {{scope-parentheses-funccall}}
 ]"                  {{scope-expression-end}}
 
@@ -30,10 +42,38 @@ c                   {{scope-string-contents}}
 )                   {{scope-parentheses-funccall}}
 ]"                  {{scope-expression-end}}
 
+TEST STRING: "[max(1)]"
+"[                  {{scope-expression-start}}
+max                 {{scope-builtin}}
+(                   {{scope-parentheses-funccall}}
+1                   {{scope-number}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
 TEST STRING: "[mAX(1)]"
 "[                  {{scope-expression-start}}
 mAX                 {{scope-builtin}}
 (                   {{scope-parentheses-funccall}}
+1                   {{scope-number}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
+TEST STRING: "[and(1,1)]"
+"[                  {{scope-expression-start}}
+and                 {{scope-logical}}
+(                   {{scope-parentheses-funccall}}
+1                   {{scope-number}}
+,                   {{scope-funcargs-separator}}
+1                   {{scope-number}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
+TEST STRING: "[aNd(1,1)]"
+"[                  {{scope-expression-start}}
+aNd                 {{scope-logical}}
+(                   {{scope-parentheses-funccall}}
+1                   {{scope-number}}
+,                   {{scope-funcargs-separator}}
 1                   {{scope-number}}
 )                   {{scope-parentheses-funccall}}
 ]"                  {{scope-expression-end}}

--- a/test/colorization/results/parameters.jsonc.txt
+++ b/test/colorization/results/parameters.jsonc.txt
@@ -6,9 +6,34 @@ parameters          {{scope-parameters}}
 )                   {{scope-parentheses-funccall}}
 ]"                  {{scope-expression-end}}
 
+TEST STRING: "[Parameters('myparam')]"
+"[                  {{scope-expression-start}}
+Parameters          {{scope-parameters}}
+(                   {{scope-parentheses-funccall}}
+'myparam'           {{scope-parameter}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
 TEST STRING: "[parameters(concat('myparam','a'))]"
 "[                  {{scope-expression-start}}
 parameters          {{scope-parameters}}
+(                   {{scope-parentheses-funccall}}
+concat              {{scope-builtin}}
+(                   {{scope-parentheses-funccall}}
+'                   {{scope-string-start}}
+myparam             {{scope-string-contents}}
+'                   {{scope-string-end}}
+,                   {{scope-funcargs-separator}}
+'                   {{scope-string-start}}
+a                   {{scope-string-contents}}
+'                   {{scope-string-end}}
+)                   {{scope-parentheses-funccall}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
+TEST STRING: "[Parameters(concat('myparam','a'))]"
+"[                  {{scope-expression-start}}
+Parameters          {{scope-parameters}}
 (                   {{scope-parentheses-funccall}}
 concat              {{scope-builtin}}
 (                   {{scope-parentheses-funccall}}

--- a/test/colorization/results/variables.jsonc.txt
+++ b/test/colorization/results/variables.jsonc.txt
@@ -6,9 +6,34 @@ variables           {{scope-variables}}
 )                   {{scope-parentheses-funccall}}
 ]"                  {{scope-expression-end}}
 
+TEST STRING: "[Variables('Myvar')]"
+"[                  {{scope-expression-start}}
+Variables           {{scope-variables}}
+(                   {{scope-parentheses-funccall}}
+'Myvar'             {{scope-variable}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
 TEST STRING: "[variables(concat('myvar','a'))]"
 "[                  {{scope-expression-start}}
 variables           {{scope-variables}}
+(                   {{scope-parentheses-funccall}}
+concat              {{scope-builtin}}
+(                   {{scope-parentheses-funccall}}
+'                   {{scope-string-start}}
+myvar               {{scope-string-contents}}
+'                   {{scope-string-end}}
+,                   {{scope-funcargs-separator}}
+'                   {{scope-string-start}}
+a                   {{scope-string-contents}}
+'                   {{scope-string-end}}
+)                   {{scope-parentheses-funccall}}
+)                   {{scope-parentheses-funccall}}
+]"                  {{scope-expression-end}}
+
+TEST STRING: "[Variables(concat('myvar','a'))]"
+"[                  {{scope-expression-start}}
+Variables           {{scope-variables}}
 (                   {{scope-parentheses-funccall}}
 concat              {{scope-builtin}}
 (                   {{scope-parentheses-funccall}}


### PR DESCRIPTION
Will not merge this until 0.7.0 released (not a regression, not high priority).

Needed some selective case-insensitive flags `(?i)`

The testcases that were meant to detect this unfortunately had incorrect results merged