### PR TITLE
Var object prop completions should retain original case

### DIFF
--- a/src/CaseInsensitiveMap.ts
+++ b/src/CaseInsensitiveMap.ts
@@ -6,21 +6,27 @@
  * Map with case-insensitive keys. Last set wins if keys differ only by case
  */
 export class CaseInsensitiveMap<TKey extends string, TValue> {
-    private _map: Map<TKey, TValue> = new Map<TKey, TValue>();
+    // Maps case-insensitive key to tuple of [case-preserved key, value]
+    private _map: Map<TKey, [TKey, TValue]> = new Map<TKey, [TKey, TValue]>();
 
     // tslint:disable-next-line: no-reserved-keywords
     public get(key: TKey): TValue | undefined {
         const found = this._map.get(<TKey>key.toLowerCase());
-        return found ? found : undefined;
+        return found ? found[1] : undefined;
     }
 
     // tslint:disable-next-line: no-reserved-keywords
     public set(key: TKey, value: TValue): CaseInsensitiveMap<TKey, TValue> {
-        this._map.set(<TKey>key.toLowerCase(), value);
+        this._map.set(<TKey>key.toLowerCase(), [key, value]);
         return this;
     }
 
+    /**
+     * Retrieve the keys, in the original casing that they were set with
+     */
     public keys(): IterableIterator<TKey> {
-        return this._map.keys();
+        const tuples: [TKey, TValue][] = Array.from(this._map.values());
+        const casePreservedKeys: TKey[] = tuples.map(tuple => tuple[0]);
+        return casePreservedKeys.values();
     }
 }

--- a/src/PositionContext.ts
+++ b/src/PositionContext.ts
@@ -571,9 +571,12 @@ export class PositionContext {
             if (!propertyPrefix) {
                 matchingPropertyNames = sourcePropertyDefinition.propertyNames;
             } else {
+                // We need to ignore casing when creating completions
+                const propertyPrefixLC = propertyPrefix.toLowerCase();
+
                 matchingPropertyNames = [];
                 for (const propertyName of sourcePropertyDefinition.propertyNames) {
-                    if (propertyName.startsWith(propertyPrefix)) {
+                    if (propertyName.toLowerCase().startsWith(propertyPrefixLC)) {
                         matchingPropertyNames.push(propertyName);
                     }
                 }

--- a/test/CaseInsensitiveMap.test.ts
+++ b/test/CaseInsensitiveMap.test.ts
@@ -29,4 +29,12 @@ suite("CaseInsensitiveMap", () => {
         map.set("ABC", "HELLO");
         assert.equal(map.get("aBC"), "HELLO");
     });
+
+    test("keys returns original casing", () => {
+        const map = new CaseInsensitiveMap<string, string>();
+        map.set("Abc", "abc");
+        map.set("def", "def");
+        const keys: string[] = Array.from(map.keys());
+        assert.deepEqual(keys, ["Abc", "def"]);
+    });
 });

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -1003,6 +1003,28 @@ suite("PositionContext", () => {
                                             []);
                 }
 
+                // Should retain original casing when completing
+                for (let i = 0; i <= 78; ++i) {
+                    completionItemsTest(`{ "variables": { "A": { "Bb": { "cC": 200 } } }, "b": "[variables('a').Bb.]" }`, i,
+                        (i === 56) ? allTestDataExpectedCompletions(56, 0) :
+                            (57 <= i && i <= 65) ? [expectedVariablesCompletion(56, 9)] :
+                                (67 <= i && i <= 68) ? [variableCompletion("A", 66, 4)] :
+                                    (70 <= i && i <= 73) ? [propertyCompletion("Bb", 71, 2)] :
+                                        (i === 74) ? [propertyCompletion("cC", 74, 0)] :
+                                            []);
+                }
+
+                // Casing shouldn't matter for finding completions
+                for (let i = 0; i <= 78; ++i) {
+                    completionItemsTest(`{ "variables": { "A": { "Bb": { "cC": 200 } } }, "b": "[variables('a').BB.Cc]" }`, i,
+                        (i === 56) ? allTestDataExpectedCompletions(56, 0) :
+                            (57 <= i && i <= 65) ? [expectedVariablesCompletion(56, 9)] :
+                                (67 <= i && i <= 68) ? [variableCompletion("A", 66, 4)] :
+                                    (70 <= i && i <= 73) ? [propertyCompletion("Bb", 71, 2)] :
+                                        (74 <= i && i <= 76) ? [propertyCompletion("cC", 74, 2)] :
+                                            []);
+                }
+
             });
 
             // CONSIDER: Use parseTemplateWithMarkers


### PR DESCRIPTION
Fixes the regression from https://dev.azure.com/devdiv/DevDiv/_boards/board/t/ARM%20Template%20Authoring/Stories/?workitem=824413
```json
{
    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
    "contentVersion": "9.0-5",
…
    "variables": {
        "apiVersions": {
            "resourcesApiVersion": "2016-09-01",
            "networkApiVersion": "2017-08-01",
            "storageApiVersion": "2017-03-30",
            "computeApiVersion": "2017-03-30"
        },
…
    "resources": [
        {
            "name": "availabilitySetDeployment",
            "condition": "[variables('enableAvailabilitySet')]",
            "type": "Microsoft.Resources/deployments",
            "apiVersion": "[variables('apiVersions').resourcesAPIVersion]",
```
The completions for variables('apiVersions').xxx should retain the original casing of the variables.