### PR TITLE
Add setting to override dotnet exe path

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,10 @@
           ],
           "default": "Warning",
           "description": "Sets the trace level in the Output window for the Azure Template Language Server (requires restart)"
+        },
+        "azureResourceManagerTools.languageServer.dotnetExePath": {
+          "type": "string",
+          "description": "(Not recommended, requires restart) If specified, overrides the use of a local version of dotnet core the extension and instead points to another installed version of dotnet.exe (must match the version needed by the extension)"
         }
       }
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,7 +15,6 @@ export const languageServerName = 'ARM Template Language Server';
 export const languageFriendlyName = 'Azure Resource Manager Template';
 export const languageId = 'arm-template';
 export const languageServerFolderName = 'languageServer';
-export const configPrefix = 'azureResourceManagerTools'; // Prefix for user settings
 export const outputWindowName = 'Azure Resource Manager Tools';
 
 // String that shows up in our errors as the source in parentheses
@@ -24,8 +23,14 @@ export const expressionsDiagnosticsSource = "arm-template (expressions)";
 // Source string for errors related to the language server starting up or failing
 export const languageServerStateSource = "arm-template";
 
+export const configPrefix = 'azureResourceManagerTools'; // Prefix for user settings
+
 export namespace configKeys {
-    export const autoDetectJsonTemplates = "autoDetectJsonTemplates";
+    export const autoDetectJsonTemplates = 'autoDetectJsonTemplates';
+    export const dotnetExePath = 'languageServer.dotnetExePath';
+    export const traceLevel = 'languageServer.traceLevel';
+    export const waitForDebugger = 'languageServer.waitForDebugger';
+    export const langServerPath = 'languageServer.path';
 }
 
 // For testing: We create a diagnostic with this message during testing to indicate when all (expression) diagnostics have been calculated

--- a/src/languageclient/startArmLanguageServer.ts
+++ b/src/languageclient/startArmLanguageServer.ts
@@ -248,6 +248,6 @@ async function ensureDependencies(dotnetExePath: string, serverDllPath: string):
     });
 }
 
-async function isFile(path: string): Promise<boolean> {
-    return (await fse.pathExists(path)) && (await fse.stat(path)).isFile();
+async function isFile(pathPath: string): Promise<boolean> {
+    return (await fse.pathExists(pathPath)) && (await fse.stat(pathPath)).isFile();
 }


### PR DESCRIPTION
This is mostly to provide a work-around if someone has trouble installing dotnet core.