### PR TITLE
Refactor HoverInfo

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -19,7 +19,6 @@
  */
 
 import * as Completion from './src/Completion';
-import * as Hover from "./src/Hover";
 import * as Json from "./src/JSON";
 import * as Language from "./src/Language";
 import * as TLE from "./src/TLE";
@@ -40,6 +39,7 @@ export { Duration } from './src/Duration';
 export { ExpressionType } from "./src/ExpressionType";
 export { ext } from './src/extensionVariables';
 export { Histogram } from "./src/Histogram";
+export { HoverInfo } from "./src/Hover";
 export { httpGet } from './src/httpGet';
 export { DefinitionKind, INamedDefinition } from "./src/INamedDefinition";
 export { IncorrectArgumentsCountIssue } from "./src/IncorrectArgumentsCountIssue";
@@ -69,7 +69,6 @@ export { UnrecognizedFunctionVisitor } from "./src/visitors/UnrecognizedFunction
 export { Completion };
 export { Json };
 export { Language };
-export { Hover };
 export { basic };
 export { Utilities };
 export { TLE };

--- a/src/AzureRMAssets.ts
+++ b/src/AzureRMAssets.ts
@@ -131,7 +131,7 @@ export class BuiltinFunctionMetadata implements IFunctionMetadata, INamedDefinit
     public get usageInfo(): IUsageInfo {
         return {
             usage: this.usage,
-            friendlyType: "function", //asdf?
+            friendlyType: "function",
             description: this.description
         };
     }

--- a/src/AzureRMAssets.ts
+++ b/src/AzureRMAssets.ts
@@ -6,6 +6,7 @@ import * as fse from 'fs-extra';
 import * as path from "path";
 import { assetsPath } from './constants';
 import { ExpressionType } from './ExpressionType';
+import { IUsageInfo } from './Hover';
 import { IFunctionMetadata, IFunctionParameterMetadata } from './IFunctionMetadata';
 import { DefinitionKind, INamedDefinition } from './INamedDefinition';
 import { StringValue } from './JSON';
@@ -125,6 +126,14 @@ export class BuiltinFunctionMetadata implements IFunctionMetadata, INamedDefinit
 
     public get usage(): string {
         return this.returnType ? `${this._usage} [${this.returnType}]` : this._usage;
+    }
+
+    public get usageInfo(): IUsageInfo {
+        return {
+            usage: this.usage,
+            friendlyType: "function", //asdf?
+            description: this.description
+        };
     }
 
     public get parameters(): IFunctionParameterMetadata[] {

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -396,28 +396,15 @@ export class AzureRMTools {
         if (deploymentTemplate) {
             return callWithTelemetryAndErrorHandlingSync('Hover', (actionContext: IActionContext): vscode.Hover | undefined => {
                 actionContext.errorHandling.suppressDisplay = true;
-                let properties = <TelemetryProperties & { hoverType?: string; tleFunctionName: string }>actionContext.telemetry.properties;
+                const properties = <TelemetryProperties & { hoverType?: string; tleFunctionName: string }>actionContext.telemetry.properties;
 
                 const context = deploymentTemplate.getContextFromDocumentLineAndColumnIndexes(position.line, position.character);
-                let hoverInfo: Hover.Info | null = context.getHoverInfo();
-                let hover: vscode.Hover;
+                const hoverInfo: Hover.HoverInfo | null = context.getHoverInfo();
 
                 if (hoverInfo) {
-                    if (hoverInfo instanceof Hover.UserNamespaceInfo) {
-                        properties.hoverType = "User Namespace";
-                    } else if (hoverInfo instanceof Hover.UserFunctionInfo) {
-                        properties.hoverType = "User Function";
-                    } else if (hoverInfo instanceof Hover.FunctionInfo) {
-                        properties.hoverType = "TLE Function";
-                        properties.tleFunctionName = hoverInfo.functionName;
-                    } else if (hoverInfo instanceof Hover.ParameterReferenceInfo) {
-                        properties.hoverType = "Parameter Reference";
-                    } else if (hoverInfo instanceof Hover.VariableReferenceInfo) {
-                        properties.hoverType = "Variable Reference";
-                    }
-
+                    properties.hoverType = hoverInfo.friendlyType;
                     const hoverRange: vscode.Range = getVSCodeRangeFromSpan(deploymentTemplate, hoverInfo.span);
-                    hover = new vscode.Hover(hoverInfo.getHoverText(), hoverRange);
+                    const hover = new vscode.Hover(hoverInfo.getHoverText(), hoverRange);
                     return hover;
                 }
 

--- a/src/INamedDefinition.ts
+++ b/src/INamedDefinition.ts
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
+import { IUsageInfo } from "./Hover";
 import * as Json from "./JSON";
 
 export enum DefinitionKind {
@@ -18,4 +19,5 @@ export enum DefinitionKind {
 export interface INamedDefinition {
     definitionKind: DefinitionKind;
     nameValue?: Json.StringValue;   // Undefined if the definition is not defined inside the template (e.g. built-in functions)
+    usageInfo: IUsageInfo;
 }

--- a/src/ParameterDefinition.ts
+++ b/src/ParameterDefinition.ts
@@ -4,6 +4,7 @@
 
 import { ExpressionType, toValidExpressionType } from './ExpressionType';
 import { assert } from './fixed_assert';
+import { IUsageInfo } from './Hover';
 import { DefinitionKind } from './INamedDefinition';
 import { IParameterDefinition } from './IParameterDefinition';
 import * as Json from "./JSON";
@@ -64,6 +65,14 @@ export class ParameterDefinition implements IParameterDefinition {
         }
 
         return null;
+    }
+
+    public get usageInfo(): IUsageInfo {
+        return {
+            usage: this.nameValue.unquotedValue,
+            friendlyType: "parameter",
+            description: this.description
+        };
     }
 
     /**

--- a/src/PositionContext.ts
+++ b/src/PositionContext.ts
@@ -12,21 +12,18 @@ import { templateKeys } from "./constants";
 import { __debugMarkPositionInString } from "./debugMarkStrings";
 import { DeploymentTemplate } from "./DeploymentTemplate";
 import { assert } from './fixed_assert';
-import * as Hover from "./Hover";
+import { HoverInfo } from "./Hover";
 import { IFunctionMetadata, IFunctionParameterMetadata } from "./IFunctionMetadata";
-import { DefinitionKind, INamedDefinition } from "./INamedDefinition";
+import { INamedDefinition } from "./INamedDefinition";
 import { IParameterDefinition } from "./IParameterDefinition";
 import * as Json from "./JSON";
 import * as language from "./Language";
-import { ParameterDefinition } from "./ParameterDefinition";
 import * as Reference from "./ReferenceList";
 import { TemplateScope } from "./TemplateScope";
 import * as TLE from "./TLE";
 import { UserFunctionDefinition } from "./UserFunctionDefinition";
 import { UserFunctionMetadata } from "./UserFunctionMetadata";
 import { UserFunctionNamespaceDefinition } from "./UserFunctionNamespaceDefinition";
-import { UserFunctionParameterDefinition } from "./UserFunctionParameterDefinition";
-import { assertNever } from "./util/assertNever";
 import { VariableDefinition } from "./VariableDefinition";
 
 /**
@@ -256,45 +253,12 @@ export class PositionContext {
         return null;
     }
 
-    public getHoverInfo(): Hover.Info | null {
+    public getHoverInfo(): HoverInfo | null {
         const reference: IReferenceSite | null = this.getReferenceSiteInfo();
         if (reference) {
             const span = reference.referenceSpan;
             const definition = reference.definition;
-
-            // tslint:disable-next-line:switch-default
-            switch (definition.definitionKind) {
-                case DefinitionKind.Namespace:
-                    if (definition instanceof UserFunctionNamespaceDefinition) {
-                        return new Hover.UserNamespaceInfo(definition, span);
-                    }
-                    break;
-                case DefinitionKind.UserFunction:
-                    if (definition instanceof UserFunctionDefinition) {
-                        return new Hover.UserFunctionInfo(definition, span);
-                    }
-                    break;
-                case DefinitionKind.BuiltinFunction:
-                    if (definition instanceof BuiltinFunctionMetadata) {
-                        const functionMetadata = definition;
-                        return new Hover.FunctionInfo(functionMetadata.fullName, functionMetadata.usage, functionMetadata.description, span);
-                    }
-                    break;
-                case DefinitionKind.Parameter:
-                    if (definition instanceof ParameterDefinition || definition instanceof UserFunctionParameterDefinition) {
-                        return Hover.ParameterReferenceInfo.fromDefinition(definition, span);
-                    }
-                    break;
-                case DefinitionKind.Variable:
-                    if (definition instanceof VariableDefinition) {
-                        return Hover.VariableReferenceInfo.fromDefinition(definition, span);
-                    }
-                    break;
-                default:
-                    return assertNever(definition.definitionKind); // Gives compile-time error if a case is missed
-            }
-
-            assert(false, `Unexpected definition type for definition kind ${definition.definitionKind}`);
+            return new HoverInfo(definition.usageInfo, span);
         }
 
         return null;

--- a/src/UserFunctionDefinition.ts
+++ b/src/UserFunctionDefinition.ts
@@ -4,9 +4,11 @@
 
 import { CachedValue } from "./CachedValue";
 import { templateKeys } from "./constants";
+import { IUsageInfo } from "./Hover";
 import { DefinitionKind, INamedDefinition } from "./INamedDefinition";
 import * as Json from "./JSON";
 import { OutputDefinition } from "./OutputDefinition";
+import { getUserFunctionUsage } from "./signatureFormatting";
 import { ScopeContext, TemplateScope } from "./TemplateScope";
 import { UserFunctionNamespaceDefinition } from "./UserFunctionNamespaceDefinition";
 import { UserFunctionParameterDefinition } from "./UserFunctionParameterDefinition";
@@ -87,5 +89,13 @@ export class UserFunctionDefinition implements INamedDefinition {
 
             return parameterDefinitions;
         });
+    }
+
+    public get usageInfo(): IUsageInfo {
+        return {
+            usage: getUserFunctionUsage(this),
+            friendlyType: "user-defined function",
+            description: undefined // CONSIDER: retrieve description from metadata
+        };
     }
 }

--- a/src/UserFunctionNamespaceDefinition.ts
+++ b/src/UserFunctionNamespaceDefinition.ts
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
+import * as os from 'os';
 import { CachedValue } from './CachedValue';
 import { assert } from './fixed_assert';
 import { IUsageInfo } from './Hover';
@@ -104,7 +105,7 @@ export class UserFunctionNamespaceDefinition implements INamedDefinition {
             .map(md => getUserFunctionUsage(md, false));
         let description: string | undefined;
         if (methodsUsage.length > 0) {
-            description = `Members:\n${methodsUsage.map(mu => `* ${mu}`).join("\n")}`;
+            description = `Members:${os.EOL}${methodsUsage.map(mu => `* ${mu}`).join(os.EOL)}`;
         } else {
             description = `No members`;
         }

--- a/src/UserFunctionNamespaceDefinition.ts
+++ b/src/UserFunctionNamespaceDefinition.ts
@@ -4,9 +4,11 @@
 
 import { CachedValue } from './CachedValue';
 import { assert } from './fixed_assert';
+import { IUsageInfo } from './Hover';
 import { DefinitionKind, INamedDefinition } from './INamedDefinition';
 import * as Json from "./JSON";
 import * as language from "./Language";
+import { getUserFunctionUsage } from './signatureFormatting';
 import { UserFunctionDefinition } from "./UserFunctionDefinition";
 
 /**
@@ -94,5 +96,23 @@ export class UserFunctionNamespaceDefinition implements INamedDefinition {
         } else {
             return undefined;
         }
+    }
+
+    public get usageInfo(): IUsageInfo {
+        const ns = this.nameValue.unquotedValue;
+        const methodsUsage: string[] = this.members
+            .map(md => getUserFunctionUsage(md, false));
+        let description: string | undefined;
+        if (methodsUsage.length > 0) {
+            description = `Members:\n${methodsUsage.map(mu => `* ${mu}`).join("\n")}`;
+        } else {
+            description = `No members`;
+        }
+
+        return {
+            usage: ns,
+            friendlyType: "user-defined namespace",
+            description // CONSIDER: retrieve description from metadata, if supported
+        };
     }
 }

--- a/src/UserFunctionParameterDefinition.ts
+++ b/src/UserFunctionParameterDefinition.ts
@@ -4,6 +4,7 @@
 
 import { ExpressionType, toValidExpressionType } from './ExpressionType';
 import { assert } from './fixed_assert';
+import { IUsageInfo } from './Hover';
 import { DefinitionKind } from './INamedDefinition';
 import { IParameterDefinition } from './IParameterDefinition';
 import * as Json from "./JSON";
@@ -53,6 +54,14 @@ export class UserFunctionParameterDefinition implements IParameterDefinition {
 
     public readonly description: string | null = null;
     public readonly defaultValue: Json.Value | null = null;
+
+    public get usageInfo(): IUsageInfo {
+        return {
+            usage: this.nameValue.unquotedValue,
+            friendlyType: "function parameter",
+            description: this.description
+        };
+    }
 
     /**
      * Convenient way of seeing what this object represents in the debugger, shouldn't be used for production code

--- a/src/VariableDefinition.ts
+++ b/src/VariableDefinition.ts
@@ -4,6 +4,7 @@
 
 import { Language } from '../extension.bundle';
 import { assert } from './fixed_assert';
+import { IUsageInfo } from './Hover';
 import { DefinitionKind, INamedDefinition } from './INamedDefinition';
 import * as Json from "./JSON";
 
@@ -11,7 +12,6 @@ import * as Json from "./JSON";
  * This class represents the definition of a top-level parameter in a deployment template.
  */
 export class VariableDefinition implements INamedDefinition {
-
     public readonly definitionKind: DefinitionKind = DefinitionKind.Variable;
 
     constructor(private readonly _property: Json.Property) {
@@ -28,6 +28,14 @@ export class VariableDefinition implements INamedDefinition {
 
     public get span(): Language.Span {
         return this._property.span;
+    }
+
+    public get usageInfo(): IUsageInfo {
+        return {
+            usage: this.nameValue.unquotedValue,
+            friendlyType: "variable",
+            description: undefined
+        };
     }
 
     /**

--- a/src/languageclient/WrappedErrorHandler.ts
+++ b/src/languageclient/WrappedErrorHandler.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as os from 'os';
 import { callWithTelemetryAndErrorHandlingSync, IActionContext, parseError } from 'vscode-azureextensionui';
 import { Message } from 'vscode-jsonrpc';
 import { CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient';
@@ -39,7 +40,7 @@ export class WrappedErrorHandler implements ErrorHandler {
             context.telemetry.properties.jsonrpcMessage = message ? message.jsonrpc : "";
             context.telemetry.measurements.secondsSinceStart = (Date.now() - this._serverStartTime) / 1000;
 
-            throw new Error(`An error occurred in the ${languageServerName}.\n\n${parseError(error).message}`);
+            throw new Error(`An error occurred in the ${languageServerName}.${os.EOL}${os.EOL}${parseError(error).message}`);
         });
 
         return this._handler.error(error, message, count);

--- a/src/languageclient/startArmLanguageServer.ts
+++ b/src/languageclient/startArmLanguageServer.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
 import { ProgressLocation, window, workspace } from 'vscode';
 import { callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync, IActionContext, parseError } from 'vscode-azureextensionui';
@@ -125,8 +126,8 @@ export async function startLanguageClient(serverDllPath: string, dotnetExePath: 
         actionContext.telemetry.properties.langServerNugetVersion = langServerVersion;
         ext.outputChannel.appendLine(`Starting ${languageServerName} at ${serverDllPath}`);
         ext.outputChannel.appendLine(`Language server nuget version: ${langServerVersion}`);
-        ext.outputChannel.appendLine(`Client options:\n${JSON.stringify(clientOptions, undefined, 2)}`);
-        ext.outputChannel.appendLine(`Server options:\n${JSON.stringify(serverOptions, undefined, 2)}`);
+        ext.outputChannel.appendLine(`Client options:${os.EOL}${JSON.stringify(clientOptions, undefined, 2)}`);
+        ext.outputChannel.appendLine(`Server options:${os.EOL}${JSON.stringify(serverOptions, undefined, 2)}`);
         client = new LanguageClient(
             languageId,
             languageFriendlyName, // Used in the Output window combobox
@@ -149,7 +150,7 @@ export async function startLanguageClient(serverDllPath: string, dotnetExePath: 
             await client.onReady();
         } catch (error) {
             throw new Error(
-                `${languageServerName}: An error occurred starting the language server.\n\n${parseError(error).message}`
+                `${languageServerName}: An error occurred starting the language server.${os.EOL}${os.EOL}${parseError(error).message}`
             );
         }
     });

--- a/test/Hover.test.ts
+++ b/test/Hover.test.ts
@@ -2,41 +2,46 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
+// tslint:disable: prefer-template
+
 import * as assert from "assert";
-import { Hover, Language } from "../extension.bundle";
+import * as os from 'os';
+import { HoverInfo, Language } from "../extension.bundle";
 
 suite("Hover", () => {
-    suite("Function", () => {
-        test("constructor(tle.FunctionMetadata,Span)", () => {
-            const fhi = new Hover.FunctionInfo("a", "b", "c", new Language.Span(17, 7));
-            assert.deepEqual("a", fhi.functionName);
-            assert.deepEqual("**b**\nc", fhi.getHoverText());
-            assert.deepEqual(new Language.Span(17, 7), fhi.span);
+    suite("HoverInfo", () => {
+        test("with description", () => {
+            const info = new HoverInfo(
+                {
+                    usage: "usage",
+                    friendlyType: "type",
+                    description: "description"
+                },
+                new Language.Span(17, 7));
+            assert.deepEqual(`**usage**${os.EOL}*(type)*${os.EOL}${os.EOL}description`, info.getHoverText());
+            assert.deepEqual(new Language.Span(17, 7), info.span);
         });
-    });
 
-    suite("ParameterReference", () => {
-        suite("constructor(ParameterDefinition,Span)", () => {
-            test("with description", () => {
-                const prhi = new Hover.ParameterReferenceInfo("a", "b", new Language.Span(2, 3));
-                assert.deepEqual("**a** (parameter)\nb", prhi.getHoverText());
-                assert.deepEqual(new Language.Span(2, 3), prhi.span);
-            });
-
-            test("with undefined description", () => {
-                // tslint:disable-next-line:no-any
-                const prhi = new Hover.ParameterReferenceInfo("a", <any>undefined, new Language.Span(2, 3));
-                assert.deepEqual("**a** (parameter)", prhi.getHoverText());
-                assert.deepEqual(new Language.Span(2, 3), prhi.span);
-            });
+        test("no description", () => {
+            const info = new HoverInfo(
+                {
+                    usage: "usage",
+                    friendlyType: "type",
+                    description: undefined
+                },
+                new Language.Span(17, 7));
+            assert.deepEqual(`**usage**${os.EOL}*(type)*`, info.getHoverText());
         });
-    });
 
-    suite("VariableReference", () => {
-        test("constructor(VariableDefinition,Span)", () => {
-            const prhi = new Hover.VariableReferenceInfo("a", new Language.Span(2, 3));
-            assert.deepEqual("**a** (variable)", prhi.getHoverText());
-            assert.deepEqual(new Language.Span(2, 3), prhi.span);
+        test("empty description", () => {
+            const info = new HoverInfo(
+                {
+                    usage: "usage",
+                    friendlyType: "type",
+                    description: ""
+                },
+                new Language.Span(17, 7));
+            assert.deepEqual(`**usage**${os.EOL}*(type)*`, info.getHoverText());
         });
     });
 });

--- a/test/UserFunctions.test.ts
+++ b/test/UserFunctions.test.ts
@@ -1354,7 +1354,7 @@ suite("User functions", () => {
             await testHover(
                 dt,
                 udfReferenceAtNamespace.index,
-                `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* string(year [int], month, day [int]) [string]`);
+                `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}Members:${os.EOL}* string(year [int], month, day [int]) [string]`);
         });
     }); // suite UDF Hover Info
 

--- a/test/UserFunctions.test.ts
+++ b/test/UserFunctions.test.ts
@@ -6,7 +6,8 @@
 // tslint:disable:no-non-null-assertion object-literal-key-quotes variable-name no-constant-condition
 
 import * as assert from "assert";
-import { DefinitionKind, DeploymentTemplate, Hover, IReferenceSite, Language, ReferenceList } from "../extension.bundle";
+import * as os from 'os';
+import { DefinitionKind, DeploymentTemplate, HoverInfo, IReferenceSite, Language, ReferenceList } from "../extension.bundle";
 import { IDeploymentTemplate } from "./support/diagnostics";
 import { parseTemplate, parseTemplateWithMarkers } from "./support/parseTemplate";
 import { stringify } from "./support/stringify";
@@ -1310,7 +1311,7 @@ suite("User functions", () => {
             expectedSpan?: Language.Span
         ): Promise<void> {
             const pc = dt.getContextFromDocumentCharacterIndex(cursorIndex);
-            let hoverInfo: Hover.Info = pc.getHoverInfo()!;
+            let hoverInfo: HoverInfo = pc.getHoverInfo()!;
             assert(hoverInfo, "Expected non-empty hover info");
             hoverInfo = hoverInfo!;
 
@@ -1325,27 +1326,27 @@ suite("User functions", () => {
 
         test("Hover over top-level parameter reference", async () => {
             const { dt, markers: { yearReference } } = await parseTemplateWithMarkers(userFuncsTemplate1, [], { ignoreWarnings: true });
-            await testHover(dt, yearReference.index, "**year** (parameter)");
+            await testHover(dt, yearReference.index, `**year**${os.EOL}*(parameter)*`);
         });
 
         test("Hover over UDF parameter reference", async () => {
             const { dt, markers: { udfyearReference } } = await parseTemplateWithMarkers(userFuncsTemplate1, [], { ignoreWarnings: true });
-            await testHover(dt, udfyearReference.index, "**year** (parameter)");
+            await testHover(dt, udfyearReference.index, `**year**${os.EOL}*(function parameter)*`);
         });
 
         test("Hover over top-level variable reference", async () => {
             const { dt, markers: { var1Reference1 } } = await parseTemplateWithMarkers(userFuncsTemplate1, [], { ignoreWarnings: true });
-            await testHover(dt, var1Reference1.index, "**var1** (variable)");
+            await testHover(dt, var1Reference1.index, `**var1**${os.EOL}*(variable)*`);
         });
 
         test("Hover over built-in function reference", async () => {
             const { dt, markers: { stringRef4 } } = await parseTemplateWithMarkers(userFuncsTemplate1, [], { ignoreWarnings: true });
-            await testHover(dt, stringRef4.index, "**string(valueToConvert)**\nConverts the specified value to String.");
+            await testHover(dt, stringRef4.index, `**string(valueToConvert)**${os.EOL}*(function)*${os.EOL}${os.EOL}Converts the specified value to String.`);
         });
 
         test("Hover over user-defined function reference's name", async () => {
             const { dt, markers: { udfReferenceAtName } } = await parseTemplateWithMarkers(userFuncsTemplate1, [], { ignoreWarnings: true });
-            await testHover(dt, udfReferenceAtName.index, "**udf.string(year [int], month, day [int]) [string]** User-defined function");
+            await testHover(dt, udfReferenceAtName.index, `**udf.string(year [int], month, day [int]) [string]**${os.EOL}*(user-defined function)*`);
         });
 
         test("Hover over user-defined function reference's namespace", async () => {
@@ -1353,7 +1354,7 @@ suite("User functions", () => {
             await testHover(
                 dt,
                 udfReferenceAtNamespace.index,
-                "**udf** User-defined namespace\n\nMembers:\n* string(year [int], month, day [int]) [string]");
+                `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* string(year [int], month, day [int]) [string]`);
         });
     }); // suite UDF Hover Info
 

--- a/test/UserNamespaceInfo.test.ts
+++ b/test/UserNamespaceInfo.test.ts
@@ -5,7 +5,8 @@
 // tslint:disable:no-unused-expression no-non-null-assertion max-func-body-length
 
 import * as assert from "assert";
-import { Hover, Language } from "../extension.bundle";
+import * as os from 'os';
+import { HoverInfo, Language } from "../extension.bundle";
 import { parseTemplate } from "./support/parseTemplate";
 
 const fakeSpan = new Language.Span(0, 0);
@@ -23,10 +24,10 @@ suite("Hover.UserNamespaceInfo", () => {
                     }
                 ]
             });
-            const info = new Hover.UserNamespaceInfo(
-                dt.topLevelScope.getFunctionNamespaceDefinition("udf")!,
+            const info = new HoverInfo(
+                dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
                 fakeSpan);
-            assert.equal(info.getHoverText(), "**udf** User-defined namespace\n\nNo members");
+            assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nNo members`);
         });
     });
 
@@ -44,10 +45,10 @@ suite("Hover.UserNamespaceInfo", () => {
                 }
             ]
         });
-        const info = new Hover.UserNamespaceInfo(
-            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!,
+        const info = new HoverInfo(
+            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), "**udf** User-defined namespace\n\nMembers:\n* date()");
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date()`);
     });
 
     test("one member, one param, no type", async () => {
@@ -67,10 +68,10 @@ suite("Hover.UserNamespaceInfo", () => {
                 }
             ]
         });
-        const info = new Hover.UserNamespaceInfo(
-            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!,
+        const info = new HoverInfo(
+            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), "**udf** User-defined namespace\n\nMembers:\n* date(param)");
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param)`);
     });
 
     test("one member, one param", async () => {
@@ -93,10 +94,10 @@ suite("Hover.UserNamespaceInfo", () => {
                 }
             ]
         });
-        const info = new Hover.UserNamespaceInfo(
-            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!,
+        const info = new HoverInfo(
+            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), "**udf** User-defined namespace\n\nMembers:\n* date(param)");
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param)`);
     });
 
     test("one member, two params", async () => {
@@ -123,10 +124,10 @@ suite("Hover.UserNamespaceInfo", () => {
                 }
             ]
         });
-        const info = new Hover.UserNamespaceInfo(
-            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!,
+        const info = new HoverInfo(
+            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), "**udf** User-defined namespace\n\nMembers:\n* date(param1 [string], param2 [securestring])");
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param1 [string], param2 [securestring])`);
     });
 
     test("two members", async () => {
@@ -161,9 +162,9 @@ suite("Hover.UserNamespaceInfo", () => {
                 }
             ]
         });
-        const info = new Hover.UserNamespaceInfo(
-            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!,
+        const info = new HoverInfo(
+            dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), "**udf** User-defined namespace\n\nMembers:\n* date(param1 [string], param2 [securestring])\n* time(param [string])");
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param1 [string], param2 [securestring])\n* time(param [string])`);
     });
 });

--- a/test/UserNamespaceInfo.test.ts
+++ b/test/UserNamespaceInfo.test.ts
@@ -27,7 +27,7 @@ suite("Hover.UserNamespaceInfo", () => {
             const info = new HoverInfo(
                 dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
                 fakeSpan);
-            assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nNo members`);
+            assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}No members`);
         });
     });
 
@@ -48,7 +48,7 @@ suite("Hover.UserNamespaceInfo", () => {
         const info = new HoverInfo(
             dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date()`);
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}Members:${os.EOL}* date()`);
     });
 
     test("one member, one param, no type", async () => {
@@ -71,7 +71,7 @@ suite("Hover.UserNamespaceInfo", () => {
         const info = new HoverInfo(
             dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param)`);
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}Members:${os.EOL}* date(param)`);
     });
 
     test("one member, one param", async () => {
@@ -97,7 +97,7 @@ suite("Hover.UserNamespaceInfo", () => {
         const info = new HoverInfo(
             dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param)`);
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}Members:${os.EOL}* date(param)`);
     });
 
     test("one member, two params", async () => {
@@ -127,7 +127,7 @@ suite("Hover.UserNamespaceInfo", () => {
         const info = new HoverInfo(
             dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param1 [string], param2 [securestring])`);
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}Members:${os.EOL}* date(param1 [string], param2 [securestring])`);
     });
 
     test("two members", async () => {
@@ -165,6 +165,6 @@ suite("Hover.UserNamespaceInfo", () => {
         const info = new HoverInfo(
             dt.topLevelScope.getFunctionNamespaceDefinition("udf")!.usageInfo,
             fakeSpan);
-        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*\n\nMembers:\n* date(param1 [string], param2 [securestring])\n* time(param [string])`);
+        assert.equal(info.getHoverText(), `**udf**${os.EOL}*(user-defined namespace)*${os.EOL}${os.EOL}Members:${os.EOL}* date(param1 [string], param2 [securestring])${os.EOL}* time(param [string])`);
     });
 });


### PR DESCRIPTION
In preparation for copy blocks

Move handling of hover info from a centralized class (Hover.Info) to the objects that are represented by hover info.