### PR TITLE
Modify code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Microsoft/vscodeazuretoolsdev
+* @microsoft/vscodearmtoolsdev @StephenWeatherford @alexgav @bhsubra


### PR DESCRIPTION
Among other things, this will affect who is added by default as code reviewers.  I created a new organization for us (https://github.com/orgs/microsoft/teams/vscodearmtoolsdev/members), but I think anybody that wants to be added has to be a member of the Microsoft organization in GitHub first.