### PR TITLE
Update vm images

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: Windows
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: windows-latest
   steps:
   - template: common/build.yml
   - template: common/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
 - job: Linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   steps:
   - template: common/build.yml
   - template: common/publish-vsix.yml # Only publish vsix from linux build since we use this to release and want to stay consistent
@@ -18,7 +18,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-latest
   steps:
   - template: common/build.yml
   - template: common/lint.yml


### PR DESCRIPTION
Got an email saying the images we're using will be removed in March. Other option is to hardcode to a later image, but using latest seemed easier and _should_ work fine.