### PR TITLE
Use a single output channel

### DIFF
--- a/src/languageclient/startArmLanguageServer.ts
+++ b/src/languageclient/startArmLanguageServer.ts
@@ -115,6 +115,7 @@ export async function startLanguageClient(serverDllPath: string, dotnetExePath: 
         let clientOptions: LanguageClientOptions = {
             documentSelector: armDeploymentDocumentSelector,
             diagnosticCollectionName: `${languageServerName} diagnostics`,
+            outputChannel: ext.outputChannel, // Use the same output channel as the extension does
             revealOutputChannelOn: RevealOutputChannelOn.Error,
             synchronize: {
                 configurationSection: configPrefix


### PR DESCRIPTION
Currently there's a separate output channel for the extension and another for the language server.  That's confusing to customers, esp when we ask them to report what they see in the output window.