### PR TITLE
Fix completion of subscription() return

### DIFF
--- a/test/FunctionReturnCompletions.test.ts
+++ b/test/FunctionReturnCompletions.test.ts
@@ -1,0 +1,43 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------------------
+
+// tslint:disable:no-unused-expression max-func-body-length promise-function-async max-line-length no-unnecessary-class
+// tslint:disable:no-non-null-assertion object-literal-key-quotes variable-name no-constant-condition
+
+import { createExpressionCompletionsTest } from "./support/createCompletionsTest";
+
+suite("Function return value completions", () => {
+    suite("Must match full function name, not just a prefix", () => {
+        createExpressionCompletionsTest(
+            '[resourceGrou().!]',
+            []);
+    });
+
+    suite("Built-in function return value completions", () => {
+
+        // REMEMBER: These are using TestData.ExpressionMetadata.json, not real metadata
+
+        createExpressionCompletionsTest(
+            '[resourceGroup().!]',
+            ["id", "properties", "name", "location", "tags"]);
+        createExpressionCompletionsTest(
+            '[subscription().!]',
+            ["displayName", "id", "subscriptionId", "tenantId"]);
+        createExpressionCompletionsTest(
+            '[DEployment().!]',
+            ["name", "properties"]);
+        createExpressionCompletionsTest(
+            '[listKeys().!]',
+            ["keys"]);
+    });
+
+    suite("Completions with property prefix", () => {
+        createExpressionCompletionsTest(
+            '[subscription().d!]',
+            ["displayName"]);
+        createExpressionCompletionsTest(
+            '[subscription().DI!]',
+            ["displayName"]);
+    });
+});

--- a/test/PositionContext.test.ts
+++ b/test/PositionContext.test.ts
@@ -12,7 +12,7 @@ import * as jsonTest from "./JSON.test";
 import { IDeploymentTemplate } from "./support/diagnostics";
 import { parseTemplate, parseTemplateWithMarkers } from "./support/parseTemplate";
 import { stringify } from "./support/stringify";
-import { allTestDataCompletionNames, allTestDataExpectedCompletions, expectedConcatCompletion, expectedCopyIndexCompletion, expectedPadLeftCompletion, expectedParametersCompletion, expectedProvidersCompletion, expectedReferenceCompletion, expectedReplaceCompletion, expectedResourceGroupCompletion, expectedResourceIdCompletion, expectedSkipCompletion, expectedSplitCompletion, expectedStringCompletion, expectedSubCompletion, expectedSubscriptionCompletion, expectedSubstringCompletion, expectedVariablesCompletion, parameterCompletion, propertyCompletion, variableCompletion } from "./TestData";
+import { allTestDataCompletionNames, allTestDataExpectedCompletions, expectedConcatCompletion, expectedCopyIndexCompletion, expectedPadLeftCompletion, expectedParametersCompletion, expectedProvidersCompletion, expectedReferenceCompletion, expectedReplaceCompletion, expectedResourceGroupCompletion, expectedResourceIdCompletion, expectedSkipCompletion, expectedSplitCompletion, expectedStringCompletion, expectedSubCompletion, expectedSubscriptionCompletion, expectedSubscriptionResourceIdCompletion, expectedSubstringCompletion, expectedVariablesCompletion, parameterCompletion, propertyCompletion, variableCompletion } from "./TestData";
 
 const IssueKind = Language.IssueKind;
 
@@ -529,6 +529,7 @@ suite("PositionContext", () => {
                             expectedStringCompletion(19, 4),
                             expectedSubCompletion(19, 4),
                             expectedSubscriptionCompletion(19, 4),
+                            expectedSubscriptionResourceIdCompletion(19, 4),
                             expectedSubstringCompletion(19, 4)
                         ] :
                             (i === 21) ? [

--- a/test/TestData.ExpressionMetadata.json
+++ b/test/TestData.ExpressionMetadata.json
@@ -256,6 +256,14 @@
             "$testData": true
         },
         {
+            "$comment": "This is important to include because it starts with 'subscription' which is also a function name and that has caused bugs before",
+            "name": "subscriptionResourceId",
+            "expectedUsage": "subscriptionResourceId([subscriptionId], resourceType, resourceName1, [resourceName2]...)",
+            "description": "Returns the unique resource identifier of a subscription scoped resource. You use this function to create a resourceId for a given resource as required by a property value.",
+            "minimumArguments": 2,
+            "maximumArguments": null
+        },
+        {
             "name": "substring",
             "expectedUsage": "substring(stringToParse, startIndex, length)",
             "description": "Returns a substring that starts at the specified character position and contains the specified number of characters.",

--- a/test/TestData.ts
+++ b/test/TestData.ts
@@ -68,6 +68,7 @@ export function allTestDataExpectedCompletions(startIndex: number, length: numbe
         expectedStringCompletion(startIndex, length),
         expectedSubCompletion(startIndex, length),
         expectedSubscriptionCompletion(startIndex, length),
+        expectedSubscriptionResourceIdCompletion(startIndex, length),
         expectedSubstringCompletion(startIndex, length),
         expectedTakeCompletion(startIndex, length),
         expectedToLowerCompletion(startIndex, length),
@@ -177,6 +178,10 @@ export function expectedSubCompletion(startIndex: number, length: number): Compl
 
 export function expectedSubscriptionCompletion(startIndex: number, length: number): Completion.Item {
     return new Completion.Item("subscription", "subscription()$0", new Language.Span(startIndex, length), "(function) subscription() [object]", "Returns details about the subscription.", Completion.CompletionKind.Function);
+}
+
+export function expectedSubscriptionResourceIdCompletion(startIndex: number, length: number): Completion.Item {
+    return new Completion.Item("subscriptionResourceId", "subscriptionResourceId($0)", new Language.Span(startIndex, length), "(function) subscriptionResourceId([subscriptionId], resourceType, resourceName1, [resourceName2]...)", "Returns the unique resource identifier of a subscription scoped resource. You use this function to create a resourceId for a given resource as required by a property value.", Completion.CompletionKind.Function);
 }
 
 export function expectedSubstringCompletion(startIndex: number, length: number): Completion.Item {

--- a/test/support/createCompletionsTest.ts
+++ b/test/support/createCompletionsTest.ts
@@ -8,6 +8,27 @@ import { IDeploymentTemplate } from "./diagnostics";
 import { parseTemplateWithMarkers } from "./parseTemplate";
 import { stringify } from './stringify';
 
+export function createExpressionCompletionsTest(
+    replacementWithBang: string,
+    // Can either be an array of completion names, or an array of
+    //   [completion name, insert text] tuples
+    expectedNamesAndInsertTexts: ([string, string][]) | (string[])
+): void {
+    const template = <IDeploymentTemplate>{
+        $schema: "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        contentVersion: "1.0.0.0",
+        resources: [],
+        outputs: {
+            o1: {
+                type: "object",
+                value: "<output1>"
+            }
+        }
+    };
+
+    createCompletionsTest(template, '<output1>', replacementWithBang, expectedNamesAndInsertTexts);
+}
+
 export function createCompletionsTest(
     template: string | Partial<IDeploymentTemplate>,
     find: string,
@@ -16,7 +37,7 @@ export function createCompletionsTest(
     //   [completion name, insert text] tuples
     expectedNamesAndInsertTexts: ([string, string][]) | (string[])
 ): void {
-    test(`Test UDF Completions: ${replacementWithBang}`, async () => {
+    test(`Test Completions: ${replacementWithBang}`, async () => {
         template = stringify(template).replace(find, replacementWithBang);
 
         const { dt, markers: { bang } } = await parseTemplateWithMarkers(template);


### PR DESCRIPTION
Fixes #526 

The problem is here:
> let functionMetadata: BuiltinFunctionMetadata | undefined = AzureRMAssets.getFunctionMetadataFromPrefix(functionName);

Because the code was getting metadata for functions with prefix subscription, it was finding both subscription() and subscriptionResourceId(), and giving up at finding two.  Should have been asking for an exact match, not a prefix match.  This code has been here forever, probably subscriptionResourceId() metadata was intruduced later, at which point at started failing.

The rest of the changes are suite fixes/additions.