### PR TITLE
Don't insert parens for completions (0.10.0)

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -485,7 +485,8 @@ export class AzureRMTools {
                 return this.onProvideCompletionItems(document, position, token);
             }
         };
-        ext.context.subscriptions.push(vscode.languages.registerCompletionItemProvider(armDeploymentDocumentSelector, completionProvider, "'", "[", "."));
+        ext.context.subscriptions.push(vscode.languages.registerCompletionItemProvider(
+            armDeploymentDocumentSelector, completionProvider, "'", "[", ".", "("));
 
         const definitionProvider: vscode.DefinitionProvider = {
             provideDefinition: (document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.Definition | undefined => {

--- a/src/Completion.ts
+++ b/src/Completion.ts
@@ -25,16 +25,12 @@ export class Item {
     public static fromFunctionMetadata(metadata: IFunctionMetadata, replaceSpan: language.Span): Item {
         // We want to show the fully-qualified name in the completion's title, but we only need to insert the
         // unqualified name, since the namespace is already there (if any)
-        let insertText: string = metadata.unqualifiedName;
-        // CONSIDER: Adding parentheses is wrong if they're already there
-        // if (metadata.maximumArguments === 0) {
-        //     // Cursor should go after the parentheses if no args
-        //     insertText += "()$0";
-        // } else {
-        //     // ... or between them if there are args
-        //     insertText += "($0)";
-        // }
+        const insertText: string = metadata.unqualifiedName;
 
+        // Note: We do *not* automtically add parentheses after the function name. This actually
+        // disrupts the normal flow that customers are expecting. Also, this means users will
+        // need to type "(" themselves, which will then open up the intellisense completion
+        // for the arguments, which otherwise wouldn't happen.
         return new Item(
             metadata.fullName,
             insertText,
@@ -46,7 +42,7 @@ export class Item {
 
     public static fromNamespaceDefinition(namespace: UserFunctionNamespaceDefinition, replaceSpan: language.Span): Item {
         const name: string = namespace.nameValue.unquotedValue;
-        let insertText: string = `${name}.$0`;
+        let insertText: string = `${name}`;
 
         return new Item(
             name,
@@ -61,7 +57,7 @@ export class Item {
     public static fromPropertyName(propertyName: string, replaceSpan: language.Span): Item {
         return new Item(
             propertyName,
-            `${propertyName}$0`,
+            `${propertyName}`,
             replaceSpan,
             "(property)", // detail  // CONSIDER: Add type, default value, etc.
             "", // description
@@ -73,7 +69,7 @@ export class Item {
         const name: string = `'${parameter.nameValue.unquotedValue}'`;
         return new Item(
             name,
-            `${name}${includeRightParenthesisInCompletion ? ")" : ""}$0`,
+            `${name}${includeRightParenthesisInCompletion ? ")" : ""}`, //asdf
             replaceSpan,
             `(parameter)`, // detail // CONSIDER: Add type, default value, etc. from property definition
             parameter.description, // description (from property definition's metadata)
@@ -84,7 +80,7 @@ export class Item {
         const variableName: string = `'${variable.nameValue.unquotedValue}'`;
         return new Item(
             variableName,
-            `${variableName}${includeRightParenthesisInCompletion ? ")" : ""}$0`,
+            `${variableName}${includeRightParenthesisInCompletion ? ")" : ""}`,
             replaceSpan,
             `(variable)`, // detail
             "", // description

--- a/src/Completion.ts
+++ b/src/Completion.ts
@@ -27,13 +27,13 @@ export class Item {
         // unqualified name, since the namespace is already there (if any)
         let insertText: string = metadata.unqualifiedName;
         // CONSIDER: Adding parentheses is wrong if they're already there
-        if (metadata.maximumArguments === 0) {
-            // Cursor should go after the parentheses if no args
-            insertText += "()$0";
-        } else {
-            // ... or between them if there are args
-            insertText += "($0)";
-        }
+        // if (metadata.maximumArguments === 0) {
+        //     // Cursor should go after the parentheses if no args
+        //     insertText += "()$0";
+        // } else {
+        //     // ... or between them if there are args
+        //     insertText += "($0)";
+        // }
 
         return new Item(
             metadata.fullName,

--- a/test/TestData.ts
+++ b/test/TestData.ts
@@ -81,149 +81,149 @@ export function allTestDataExpectedCompletions(startIndex: number, length: numbe
 }
 
 export function expectedAddCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("add", "add($0)", new Language.Span(startIndex, length), "(function) add(operand1, operand2)", "Returns the sum of the two provided integers.", Completion.CompletionKind.Function);
+    return new Completion.Item("add", "add", new Language.Span(startIndex, length), "(function) add(operand1, operand2)", "Returns the sum of the two provided integers.", Completion.CompletionKind.Function);
 }
 
 export function expectedBase64Completion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("base64", "base64($0)", new Language.Span(startIndex, length), "(function) base64(inputString)", "Returns the base64 representation of the input string.", Completion.CompletionKind.Function);
+    return new Completion.Item("base64", "base64", new Language.Span(startIndex, length), "(function) base64(inputString)", "Returns the base64 representation of the input string.", Completion.CompletionKind.Function);
 }
 
 export function expectedConcatCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("concat", "concat($0)", new Language.Span(startIndex, length), "(function) concat(arg1, arg2, arg3, ...)", "Combines multiple values and returns the concatenated result. This function can take any number of arguments, and can accept either strings or arrays for the parameters.", Completion.CompletionKind.Function);
+    return new Completion.Item("concat", "concat", new Language.Span(startIndex, length), "(function) concat(arg1, arg2, arg3, ...)", "Combines multiple values and returns the concatenated result. This function can take any number of arguments, and can accept either strings or arrays for the parameters.", Completion.CompletionKind.Function);
 }
 
 export function expectedCopyIndexCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("copyIndex", "copyIndex($0)", new Language.Span(startIndex, length), "(function) copyIndex([offset]) or copyIndex(loopName, [offset])", "Returns the current index of an iteration loop.\nThis function is always used with a copy object.", Completion.CompletionKind.Function);
+    return new Completion.Item("copyIndex", "copyIndex", new Language.Span(startIndex, length), "(function) copyIndex([offset]) or copyIndex(loopName, [offset])", "Returns the current index of an iteration loop.\nThis function is always used with a copy object.", Completion.CompletionKind.Function);
 }
 
 export function expectedDeploymentCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("deployment", "deployment()$0", new Language.Span(startIndex, length), "(function) deployment() [object]", "Returns information about the current deployment operation. This function returns the object that is passed during deployment. The properties in the returned object will differ based on whether the deployment object is passed as a link or as an in-line object.", Completion.CompletionKind.Function);
+    return new Completion.Item("deployment", "deployment", new Language.Span(startIndex, length), "(function) deployment() [object]", "Returns information about the current deployment operation. This function returns the object that is passed during deployment. The properties in the returned object will differ based on whether the deployment object is passed as a link or as an in-line object.", Completion.CompletionKind.Function);
 }
 
 export function expectedDivCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("div", "div($0)", new Language.Span(startIndex, length), "(function) div(operand1, operand2)", "Returns the integer division of the two provided integers.", Completion.CompletionKind.Function);
+    return new Completion.Item("div", "div", new Language.Span(startIndex, length), "(function) div(operand1, operand2)", "Returns the integer division of the two provided integers.", Completion.CompletionKind.Function);
 }
 
 export function expectedEqualsCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("equals", "equals($0)", new Language.Span(startIndex, length), "(function) equals(arg1, arg2)", "Checks whether two values equal each other.", Completion.CompletionKind.Function);
+    return new Completion.Item("equals", "equals", new Language.Span(startIndex, length), "(function) equals(arg1, arg2)", "Checks whether two values equal each other.", Completion.CompletionKind.Function);
 }
 
 export function expectedIntCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("int", "int($0)", new Language.Span(startIndex, length), "(function) int(valueToConvert)", "Converts the specified value to Integer.", Completion.CompletionKind.Function);
+    return new Completion.Item("int", "int", new Language.Span(startIndex, length), "(function) int(valueToConvert)", "Converts the specified value to Integer.", Completion.CompletionKind.Function);
 }
 
 export function expectedLengthCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("length", "length($0)", new Language.Span(startIndex, length), "(function) length(array/string)", "Returns the number of elements in an array or the number of characters in a string. You can use this function with an array to specify the number of iterations when creating resources.", Completion.CompletionKind.Function);
+    return new Completion.Item("length", "length", new Language.Span(startIndex, length), "(function) length(array/string)", "Returns the number of elements in an array or the number of characters in a string. You can use this function with an array to specify the number of iterations when creating resources.", Completion.CompletionKind.Function);
 }
 
 export function expectedListKeysCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("listKeys", "listKeys($0)", new Language.Span(startIndex, length), "(function) listKeys(resourceName/resourceIdentifier, apiVersion) [object]", "Returns the keys of a storage account. The resourceId can be specified by using the resourceId function or by using the format providerNamespace/resourceType/resourceName. You can use the function to get the primary (key[0]) and secondary key (key[1]).", Completion.CompletionKind.Function);
+    return new Completion.Item("listKeys", "listKeys", new Language.Span(startIndex, length), "(function) listKeys(resourceName/resourceIdentifier, apiVersion) [object]", "Returns the keys of a storage account. The resourceId can be specified by using the resourceId function or by using the format providerNamespace/resourceType/resourceName. You can use the function to get the primary (key[0]) and secondary key (key[1]).", Completion.CompletionKind.Function);
 }
 
 export function expectedListPackageCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("listPackage", "listPackage($0)", new Language.Span(startIndex, length), "(function) listPackage(resourceName\/resourceIdentifier, apiVersion)", "Lists the virtual network gateway package. The resourceId can be specified by using the resourceId function or by using the format providerNamespace/resourceType/resourceName.", Completion.CompletionKind.Function);
+    return new Completion.Item("listPackage", "listPackage", new Language.Span(startIndex, length), "(function) listPackage(resourceName\/resourceIdentifier, apiVersion)", "Lists the virtual network gateway package. The resourceId can be specified by using the resourceId function or by using the format providerNamespace/resourceType/resourceName.", Completion.CompletionKind.Function);
 }
 
 export function expectedModCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("mod", "mod($0)", new Language.Span(startIndex, length), "(function) mod(operand1, operand2)", "Returns the remainder of the integer division using the two provided integers.", Completion.CompletionKind.Function);
+    return new Completion.Item("mod", "mod", new Language.Span(startIndex, length), "(function) mod(operand1, operand2)", "Returns the remainder of the integer division using the two provided integers.", Completion.CompletionKind.Function);
 }
 
 export function expectedMulCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("mul", "mul($0)", new Language.Span(startIndex, length), "(function) mul(operand1, operand2)", "Returns the multiplication of the two provided integers.", Completion.CompletionKind.Function);
+    return new Completion.Item("mul", "mul", new Language.Span(startIndex, length), "(function) mul(operand1, operand2)", "Returns the multiplication of the two provided integers.", Completion.CompletionKind.Function);
 }
 
 export function expectedPadLeftCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("padLeft", "padLeft($0)", new Language.Span(startIndex, length), "(function) padLeft(stringToPad, totalLength, paddingCharacter)", "Returns a right-aligned string by adding characters to the left until reaching the total specified length.", Completion.CompletionKind.Function);
+    return new Completion.Item("padLeft", "padLeft", new Language.Span(startIndex, length), "(function) padLeft(stringToPad, totalLength, paddingCharacter)", "Returns a right-aligned string by adding characters to the left until reaching the total specified length.", Completion.CompletionKind.Function);
 }
 
 export function expectedParametersCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("parameters", "parameters($0)", new Language.Span(startIndex, length), "(function) parameters(parameterName)", "Returns a parameter value. The specified parameter name must be defined in the parameters section of the template.", Completion.CompletionKind.Function);
+    return new Completion.Item("parameters", "parameters", new Language.Span(startIndex, length), "(function) parameters(parameterName)", "Returns a parameter value. The specified parameter name must be defined in the parameters section of the template.", Completion.CompletionKind.Function);
 }
 
 export function expectedProvidersCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("providers", "providers($0)", new Language.Span(startIndex, length), "(function) providers(providerNamespace, [resourceType])", "Return information about a resource provider and its supported resource types. If not type is provided, all of the supported types are returned.", Completion.CompletionKind.Function);
+    return new Completion.Item("providers", "providers", new Language.Span(startIndex, length), "(function) providers(providerNamespace, [resourceType])", "Return information about a resource provider and its supported resource types. If not type is provided, all of the supported types are returned.", Completion.CompletionKind.Function);
 }
 
 export function expectedReferenceCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("reference", "reference($0)", new Language.Span(startIndex, length), "(function) reference(resourceName/resourceIdentifier, [apiVersion], ['Full'])", "Enables an expression to derive its value from another resource's runtime state.", Completion.CompletionKind.Function);
+    return new Completion.Item("reference", "reference", new Language.Span(startIndex, length), "(function) reference(resourceName/resourceIdentifier, [apiVersion], ['Full'])", "Enables an expression to derive its value from another resource's runtime state.", Completion.CompletionKind.Function);
 }
 
 export function expectedReplaceCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("replace", "replace($0)", new Language.Span(startIndex, length), "(function) replace(originalString, oldCharacter, newCharacter)", "Returns a new string with all instances of one character in the specified string replaced by another character.", Completion.CompletionKind.Function);
+    return new Completion.Item("replace", "replace", new Language.Span(startIndex, length), "(function) replace(originalString, oldCharacter, newCharacter)", "Returns a new string with all instances of one character in the specified string replaced by another character.", Completion.CompletionKind.Function);
 }
 
 export function expectedResourceGroupCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("resourceGroup", "resourceGroup()$0", new Language.Span(startIndex, length), "(function) resourceGroup() [object]", "Returns a structured object that represents the current resource group.", Completion.CompletionKind.Function);
+    return new Completion.Item("resourceGroup", "resourceGroup", new Language.Span(startIndex, length), "(function) resourceGroup() [object]", "Returns a structured object that represents the current resource group.", Completion.CompletionKind.Function);
 }
 
 export function expectedResourceIdCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("resourceId", "resourceId($0)", new Language.Span(startIndex, length), "(function) resourceId([subscriptionId], [resourceGroupName], resourceType, resourceName1, [resourceName2]...)", "Returns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template.", Completion.CompletionKind.Function);
+    return new Completion.Item("resourceId", "resourceId", new Language.Span(startIndex, length), "(function) resourceId([subscriptionId], [resourceGroupName], resourceType, resourceName1, [resourceName2]...)", "Returns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template.", Completion.CompletionKind.Function);
 }
 
 export function expectedSkipCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("skip", "skip($0)", new Language.Span(startIndex, length), "(function) skip(originalValue, numberToSkip)", "Returns an array or string with all of the elements or characters after the specified number in the array or string.", Completion.CompletionKind.Function);
+    return new Completion.Item("skip", "skip", new Language.Span(startIndex, length), "(function) skip(originalValue, numberToSkip)", "Returns an array or string with all of the elements or characters after the specified number in the array or string.", Completion.CompletionKind.Function);
 }
 
 export function expectedSplitCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("split", "split($0)", new Language.Span(startIndex, length), "(function) split(inputString, delimiter)", "Returns an array of strings that contains the substrings of the input string that are delimited by the sent delimiters.", Completion.CompletionKind.Function);
+    return new Completion.Item("split", "split", new Language.Span(startIndex, length), "(function) split(inputString, delimiter)", "Returns an array of strings that contains the substrings of the input string that are delimited by the sent delimiters.", Completion.CompletionKind.Function);
 }
 
 export function expectedStringCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("string", "string($0)", new Language.Span(startIndex, length), "(function) string(valueToConvert)", "Converts the specified value to String.", Completion.CompletionKind.Function);
+    return new Completion.Item("string", "string", new Language.Span(startIndex, length), "(function) string(valueToConvert)", "Converts the specified value to String.", Completion.CompletionKind.Function);
 }
 
 export function expectedSubCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("sub", "sub($0)", new Language.Span(startIndex, length), "(function) sub(operand1, operand2)", "Returns the subtraction of the two provided integers.", Completion.CompletionKind.Function);
+    return new Completion.Item("sub", "sub", new Language.Span(startIndex, length), "(function) sub(operand1, operand2)", "Returns the subtraction of the two provided integers.", Completion.CompletionKind.Function);
 }
 
 export function expectedSubscriptionCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("subscription", "subscription()$0", new Language.Span(startIndex, length), "(function) subscription() [object]", "Returns details about the subscription.", Completion.CompletionKind.Function);
+    return new Completion.Item("subscription", "subscription", new Language.Span(startIndex, length), "(function) subscription() [object]", "Returns details about the subscription.", Completion.CompletionKind.Function);
 }
 
 export function expectedSubscriptionResourceIdCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("subscriptionResourceId", "subscriptionResourceId($0)", new Language.Span(startIndex, length), "(function) subscriptionResourceId([subscriptionId], resourceType, resourceName1, [resourceName2]...)", "Returns the unique resource identifier of a subscription scoped resource. You use this function to create a resourceId for a given resource as required by a property value.", Completion.CompletionKind.Function);
+    return new Completion.Item("subscriptionResourceId", "subscriptionResourceId", new Language.Span(startIndex, length), "(function) subscriptionResourceId([subscriptionId], resourceType, resourceName1, [resourceName2]...)", "Returns the unique resource identifier of a subscription scoped resource. You use this function to create a resourceId for a given resource as required by a property value.", Completion.CompletionKind.Function);
 }
 
 export function expectedSubstringCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("substring", "substring($0)", new Language.Span(startIndex, length), "(function) substring(stringToParse, startIndex, length)", "Returns a substring that starts at the specified character position and contains the specified number of characters.", Completion.CompletionKind.Function);
+    return new Completion.Item("substring", "substring", new Language.Span(startIndex, length), "(function) substring(stringToParse, startIndex, length)", "Returns a substring that starts at the specified character position and contains the specified number of characters.", Completion.CompletionKind.Function);
 }
 
 export function expectedTakeCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("take", "take($0)", new Language.Span(startIndex, length), "(function) take(originalValue, numberToTake)", "Returns an array or string with the specified number of elements or characters from the start of the array or string.", Completion.CompletionKind.Function);
+    return new Completion.Item("take", "take", new Language.Span(startIndex, length), "(function) take(originalValue, numberToTake)", "Returns an array or string with the specified number of elements or characters from the start of the array or string.", Completion.CompletionKind.Function);
 }
 
 export function expectedToLowerCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("toLower", "toLower($0)", new Language.Span(startIndex, length), "(function) toLower(string)", "Converts the specified string to lower case.", Completion.CompletionKind.Function);
+    return new Completion.Item("toLower", "toLower", new Language.Span(startIndex, length), "(function) toLower(string)", "Converts the specified string to lower case.", Completion.CompletionKind.Function);
 }
 
 export function expectedToUpperCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("toUpper", "toUpper($0)", new Language.Span(startIndex, length), "(function) toUpper(string)", "Converts the specified string to upper case.", Completion.CompletionKind.Function);
+    return new Completion.Item("toUpper", "toUpper", new Language.Span(startIndex, length), "(function) toUpper(string)", "Converts the specified string to upper case.", Completion.CompletionKind.Function);
 }
 
 export function expectedTrimCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("trim", "trim($0)", new Language.Span(startIndex, length), "(function) trim(stringToTrim)", "Removes all leading and trailing white-space characters from the specified string.", Completion.CompletionKind.Function);
+    return new Completion.Item("trim", "trim", new Language.Span(startIndex, length), "(function) trim(stringToTrim)", "Removes all leading and trailing white-space characters from the specified string.", Completion.CompletionKind.Function);
 }
 
 export function expectedUniqueStringCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("uniqueString", "uniqueString($0)", new Language.Span(startIndex, length), "(function) uniqueString(stringForCreatingUniqueString, ...)", "Performs a 64-bit hash of the provided strings to create a unique string. This function is helpful when you need to create a unique name for a resource. You provide parameter values that represent the level of uniqueness for the result. You can specify whether the name is unique for your subscription, resource group, or deployment.", Completion.CompletionKind.Function);
+    return new Completion.Item("uniqueString", "uniqueString", new Language.Span(startIndex, length), "(function) uniqueString(stringForCreatingUniqueString, ...)", "Performs a 64-bit hash of the provided strings to create a unique string. This function is helpful when you need to create a unique name for a resource. You provide parameter values that represent the level of uniqueness for the result. You can specify whether the name is unique for your subscription, resource group, or deployment.", Completion.CompletionKind.Function);
 }
 
 export function expectedUriCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("uri", "uri($0)", new Language.Span(startIndex, length), "(function) uri(baseUri, relativeUri)", "Creates an absolute URI by combining the baseUri and the relativeUri string.", Completion.CompletionKind.Function);
+    return new Completion.Item("uri", "uri", new Language.Span(startIndex, length), "(function) uri(baseUri, relativeUri)", "Creates an absolute URI by combining the baseUri and the relativeUri string.", Completion.CompletionKind.Function);
 }
 
 export function expectedVariablesCompletion(startIndex: number, length: number): Completion.Item {
-    return new Completion.Item("variables", "variables($0)", new Language.Span(startIndex, length), "(function) variables(variableName)", "Returns the value of variable. The specified variable name must be defined in the variables section of the template.", Completion.CompletionKind.Function);
+    return new Completion.Item("variables", "variables", new Language.Span(startIndex, length), "(function) variables(variableName)", "Returns the value of variable. The specified variable name must be defined in the variables section of the template.", Completion.CompletionKind.Function);
 }
 
 export function parameterCompletion(parameterName: string, startIndex: number, length: number, includeRightParenthesis: boolean = true): Completion.Item {
-    return new Completion.Item(`'${parameterName}'`, `'${parameterName}'${includeRightParenthesis ? ")" : ""}$0`, new Language.Span(startIndex, length), "(parameter)", undefined, Completion.CompletionKind.Parameter);
+    return new Completion.Item(`'${parameterName}'`, `'${parameterName}'${includeRightParenthesis ? ")" : ""}`, new Language.Span(startIndex, length), "(parameter)", undefined, Completion.CompletionKind.Parameter);
 }
 
 export function propertyCompletion(propertyName: string, startIndex: number, length: number): Completion.Item {
-    return new Completion.Item(propertyName, `${propertyName}$0`, new Language.Span(startIndex, length), "(property)", "", Completion.CompletionKind.Property);
+    return new Completion.Item(propertyName, `${propertyName}`, new Language.Span(startIndex, length), "(property)", "", Completion.CompletionKind.Property);
 }
 
 export function variableCompletion(variableName: string, startIndex: number, length: number, includeRightParenthesis: boolean = true): Completion.Item {
-    return new Completion.Item(`'${variableName}'`, `'${variableName}'${includeRightParenthesis ? ")" : ""}$0`, new Language.Span(startIndex, length), "(variable)", "", Completion.CompletionKind.Variable);
+    return new Completion.Item(`'${variableName}'`, `'${variableName}'${includeRightParenthesis ? ")" : ""}`, new Language.Span(startIndex, length), "(variable)", "", Completion.CompletionKind.Variable);
 }

--- a/test/UserFunctions.test.ts
+++ b/test/UserFunctions.test.ts
@@ -1777,16 +1777,16 @@ suite("User functions", () => {
         };
 
         const allBuiltinsExpectedCompletions = allTestDataExpectedCompletions(0, 0).map(c => <[string, string]>[c.name, c.insertText]);
-        const allNamespaceExpectedCompletions: [string, string][] = [["mixedCaseNamespace", "mixedCaseNamespace.$0"], ["udf", "udf.$0"]];
+        const allNamespaceExpectedCompletions: [string, string][] = [["mixedCaseNamespace", "mixedCaseNamespace"], ["udf", "udf"]];
         const allUdfNsFunctionsCompletions: [string, string][] = [
-            ["udf.mixedCaseFunc", "mixedCaseFunc()$0"],
-            ["udf.string", "string($0)"],
-            ["udf.parameters", "parameters($0)"],
-            ["udf.udf", "udf($0)"],
-            ["udf.udf2", "udf2()$0"],
-            ["udf.udf3", "udf3()$0"],
-            ["udf.udf34", "udf34()$0"]];
-        const allMixedCaseNsFunctionsCompletions: [string, string][] = [["mixedCaseNamespace.howdy", "howdy()$0"]];
+            ["udf.mixedCaseFunc", "mixedCaseFunc"],
+            ["udf.string", "string"],
+            ["udf.parameters", "parameters"],
+            ["udf.udf", "udf"],
+            ["udf.udf2", "udf2"],
+            ["udf.udf3", "udf3"],
+            ["udf.udf34", "udf34"]];
+        const allMixedCaseNsFunctionsCompletions: [string, string][] = [["mixedCaseNamespace.howdy", "howdy"]];
 
         suite("Completing UDF function names", () => {
             suite("Completing udf.xxx gives udf's functions starting with xxx - not found", () => {
@@ -1797,27 +1797,27 @@ suite("User functions", () => {
 
             suite("Completing inside xxx in udf.xxx gives only udf's functions starting with xxx", () => {
                 // $0 indicates where the cursor should be placed after replacement
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.p!', [["udf.parameters", "parameters($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.u!', [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.ud!', [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf!', [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf2!', [["udf.udf2", "udf2()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf3!', [["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf34!', [["udf.udf34", "udf34()$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.p!', [["udf.parameters", "parameters"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.u!', [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.ud!', [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf!', [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf2!', [["udf.udf2", "udf2"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf3!', [["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udf34!', [["udf.udf34", "udf34"]]);
             });
 
             suite("Completing udf.xxx gives udf's functions starting with xxx - case insensitive", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.P!', [["udf.parameters", "parameters($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.U!', [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.uD!', [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udF!', [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.MIXEDCase!', [["udf.mixedCaseFunc", "mixedCaseFunc()$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.P!', [["udf.parameters", "parameters"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.U!', [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.uD!', [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.udF!', [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.MIXEDCase!', [["udf.mixedCaseFunc", "mixedCaseFunc"]]);
             });
 
             suite("Completing built-in functions inside functions", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'param!', [["parameters", "parameters($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'p!', [["padLeft", "padLeft($0)"], ["parameters", "parameters($0)"], ["providers", "providers($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'P!', [["padLeft", "padLeft($0)"], ["parameters", "parameters($0)"], ["providers", "providers($0)"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'param!', [["parameters", "parameters"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'p!', [["padLeft", "padLeft"], ["parameters", "parameters"], ["providers", "providers"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'P!', [["padLeft", "padLeft"], ["parameters", "parameters"], ["providers", "providers"]]);
             });
 
             suite("Completing built-in functions with UDF function names returns empty", () => {
@@ -1825,7 +1825,7 @@ suite("User functions", () => {
             });
 
             suite("Completing udf.param does not find built-in parameters function", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.param!', [["udf.parameters", "parameters($0)"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf.param!', [["udf.parameters", "parameters"]]);
             });
 
             suite("Completing udf. gives udf's functions", () => {
@@ -1842,10 +1842,10 @@ suite("User functions", () => {
             });
 
             suite("Completing in middle of function name", () => {
-                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.!udf34", [["udf.mixedCaseFunc", "mixedCaseFunc()$0"], ["udf.string", "string($0)"], ["udf.parameters", "parameters($0)"], ["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.u!df34", [["udf.udf", "udf($0)"], ["udf.udf2", "udf2()$0"], ["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.udf3!4", [["udf.udf3", "udf3()$0"], ["udf.udf34", "udf34()$0"]]);
-                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.udf34!", [["udf.udf34", "udf34()$0"]]);
+                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.!udf34", [["udf.mixedCaseFunc", "mixedCaseFunc"], ["udf.string", "string"], ["udf.parameters", "parameters"], ["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.u!df34", [["udf.udf", "udf"], ["udf.udf2", "udf2"], ["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.udf3!4", [["udf.udf3", "udf3"], ["udf.udf34", "udf34"]]);
+                createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.udf34!", [["udf.udf34", "udf34"]]);
                 createCompletionsTest(userFuncsTemplate2, "<output1>", "udf.udf345!", []);
             });
         }); // end Completing UDF function names
@@ -1857,21 +1857,21 @@ suite("User functions", () => {
             });
 
             suite("Only matches namespace", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'ud!', [["udf", "udf.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf!', [["udf", "udf.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixedCase!', [["mixedCaseNamespace", "mixedCaseNamespace.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixedCaseNamespace!', [["mixedCaseNamespace", "mixedCaseNamespace.$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'ud!', [["udf", "udf"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf!', [["udf", "udf"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixedCase!', [["mixedCaseNamespace", "mixedCaseNamespace"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixedCaseNamespace!', [["mixedCaseNamespace", "mixedCaseNamespace"]]);
             });
 
             suite("Only matches namespace - case insensitive", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'ud!', [["udf", "udf.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf!', [["udf", "udf.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'MIXEDCASE!', [["mixedCaseNamespace", "mixedCaseNamespace.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixedCASENAMESPACE!', [["mixedCaseNamespace", "mixedCaseNamespace.$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'ud!', [["udf", "udf"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf!', [["udf", "udf"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'MIXEDCASE!', [["mixedCaseNamespace", "mixedCaseNamespace"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixedCASENAMESPACE!', [["mixedCaseNamespace", "mixedCaseNamespace"]]);
             });
 
             suite("Matches namespaces and built-in functions", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'u!', [["udf", "udf.$0"], ["uniqueString", "uniqueString($0)"], ["uri", "uri($0)"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'u!', [["udf", "udf"], ["uniqueString", "uniqueString"], ["uri", "uri"]]);
             });
         }); // end Completing UDF namespaces
 
@@ -1883,18 +1883,18 @@ suite("User functions", () => {
 
             suite("Matches namespaces and built-in functions", () => {
                 createCompletionsTest(userFuncsTemplate2, '<output1>', '!udf.string', [...allNamespaceExpectedCompletions, ...allBuiltinsExpectedCompletions]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'u!df.string', [["udf", "udf.$0"], ["uniqueString", "uniqueString($0)"], ["uri", "uri($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'ud!f.abc', [["udf", "udf.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf!.abc', [["udf", "udf.$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixed!Ca.abc', [["mixedCaseNamespace", "mixedCaseNamespace.$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'u!df.string', [["udf", "udf"], ["uniqueString", "uniqueString"], ["uri", "uri"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'ud!f.abc', [["udf", "udf"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'udf!.abc', [["udf", "udf"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'mixed!Ca.abc', [["mixedCaseNamespace", "mixedCaseNamespace"]]);
             });
 
             suite("Parameters in outer scope", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'parameters!', [["parameters", "parameters($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'parameters(!', [["'year'", "'year')$0"], ["'apiVersion'", "'apiVersion')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'parameters(!)', [["'year'", "'year')$0"], ["'apiVersion'", "'apiVersion')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', "parameters('!y", [["'year'", "'year')$0"], ["'apiVersion'", "'apiVersion')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', "parameters('y!", [["'year'", "'year')$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'parameters!', [["parameters", "parameters"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'parameters(!', [["'year'", "'year')"], ["'apiVersion'", "'apiVersion')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'parameters(!)', [["'year'", "'year')"], ["'apiVersion'", "'apiVersion')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', "parameters('!y", [["'year'", "'year')"], ["'apiVersion'", "'apiVersion')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', "parameters('y!", [["'year'", "'year')"]]);
 
                 // Don't complete parameters against UDF with same name
                 createCompletionsTest(userFuncsTemplate2, '<output1>', "udf.parameters('y!", []);
@@ -1902,19 +1902,19 @@ suite("User functions", () => {
 
             suite("Parameters in function scope", () => {
                 // Parameter completions should only be parameters inside the function
-                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'parameters!', [["parameters", "parameters($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'parameters(!', [["'year'", "'year')$0"], ["'day'", "'day')$0"], ["'month'", "'month')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', "parameters('y!", [["'year'", "'year')$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'parameters!', [["parameters", "parameters"]]);
+                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'parameters(!', [["'year'", "'year')"], ["'day'", "'day')"], ["'month'", "'month')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', "parameters('y!", [["'year'", "'year')"]]);
             });
 
             suite("Variables in outer scope", () => {
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'variables!', [["variables", "variables($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'variables(!', [["'var1'", "'var1')$0"], ["'var2'", "'var2')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', 'variables(!)', [["'var1'", "'var1')$0"], ["'var2'", "'var2')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('!y", [["'var1'", "'var1')$0"], ["'var2'", "'var2')$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'variables!', [["variables", "variables"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'variables(!', [["'var1'", "'var1')"], ["'var2'", "'var2')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', 'variables(!)', [["'var1'", "'var1')"], ["'var2'", "'var2')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('!y", [["'var1'", "'var1')"], ["'var2'", "'var2')"]]);
                 createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('y!", []);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('v!", [["'var1'", "'var1')$0"], ["'var2'", "'var2')$0"]]);
-                createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('var1!", [["'var1'", "'var1')$0"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('v!", [["'var1'", "'var1')"], ["'var2'", "'var2')"]]);
+                createCompletionsTest(userFuncsTemplate2, '<output1>', "variables('var1!", [["'var1'", "'var1')"]]);
 
                 // Don't complete variables against UDF with same name
                 createCompletionsTest(userFuncsTemplate2, '<output1>', "udf.variables('var1!", []);
@@ -1922,7 +1922,7 @@ suite("User functions", () => {
 
             suite("Variables in function scope", () => {
                 // CONSIDER: Ideally this would not return a 'variables' completion at all
-                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'variables!', [["variables", "variables($0)"]]);
+                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'variables!', [["variables", "variables"]]);
 
                 // No variables availabe in function scope
                 createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'variables(!', []);
@@ -1930,8 +1930,8 @@ suite("User functions", () => {
 
             suite("User namespaces and functions not available in function scope", () => {
                 createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', '!udf.string', [...allBuiltinsExpectedCompletions]);
-                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'u!df.string', [["uniqueString", "uniqueString($0)"], ["uri", "uri($0)"]]);
-                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'u!', [["uniqueString", "uniqueString($0)"], ["uri", "uri($0)"]]);
+                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'u!df.string', [["uniqueString", "uniqueString"], ["uri", "uri"]]);
+                createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'u!', [["uniqueString", "uniqueString"], ["uri", "uri"]]);
                 createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'udf!.string', []);
                 createCompletionsTest(userFuncsTemplate2, '<stringOutputValue>', 'udf.!', []);
             });

--- a/test/functional/sortTemplate.test.ts
+++ b/test/functional/sortTemplate.test.ts
@@ -12,6 +12,7 @@ import * as assert from 'assert';
 import * as fse from 'fs-extra';
 import { commands, window, workspace } from "vscode";
 import { getTempFilePath } from "../support/getTempFilePath";
+import { DISABLE_SLOW_TESTS } from '../testConstants';
 
 suite("SortTemplate", async (): Promise<void> => {
     const topLevelCommand = 'azurerm-vscode-tools.sortTopLevel';
@@ -20,6 +21,10 @@ suite("SortTemplate", async (): Promise<void> => {
     const resourcesCommand = 'azurerm-vscode-tools.sortResources';
     const outputsCommand = 'azurerm-vscode-tools.sortOutputs';
     const functionsCommand = 'azurerm-vscode-tools.sortFunctions';
+
+    if (DISABLE_SLOW_TESTS) {
+        return;
+    }
 
     async function testSortTemplate(command: string, template: String, expected: String): Promise<void> {
         const tempPath = getTempFilePath(`sortTemplate`, '.azrm');


### PR DESCRIPTION
Fixes #501
Fixes #361 
Related to #556

@neilpeterson This is a quick change that these things:
1) stops inserting open parens for function calls
2) stops inserting "." when completing a user-defined namespace in a function call
3) adds "(" and "," to Intellisense triggers

CONSIDER: How to keep completion list showing after typing a space (e.g. "concat(1,<space>")

I think this really improves the flow.  
It also fixes this bug: https://github.com/microsoft/vscode-azurearmtools/issues/361