### PR TITLE
Parameter file intellisense part 2

### DIFF
--- a/src/DeploymentDocument.ts
+++ b/src/DeploymentDocument.ts
@@ -4,6 +4,7 @@
 
 import { CodeAction, CodeActionContext, Command, Range, Selection, Uri } from "vscode";
 import { CachedValue } from "./CachedValue";
+import { __debugMarkPositionInString, __debugMarkRangeInString } from "./debugMarkStrings";
 import { INamedDefinition } from "./INamedDefinition";
 import * as Json from "./JSON";
 import * as language from "./Language";
@@ -36,6 +37,15 @@ export abstract class DeploymentDocument {
         this._topLevelValue = Json.asObjectValue(this._jsonParseResult.value);
     }
 
+    // tslint:disable-next-line:function-name
+    public _debugShowTextAt(position: number | language.Span): string {
+        if (position instanceof language.Span) {
+            return __debugMarkRangeInString(this.documentText, position.startIndex, position.length);
+        } else {
+            return __debugMarkPositionInString(this.documentText, position);
+        }
+    }
+
     /**
      * Get the document text as a string.
      */
@@ -44,7 +54,7 @@ export abstract class DeploymentDocument {
     }
 
     /**
-     * The unique identifier for this deployment template. Usually this will be a URI to the document.
+     * The unique identifier for this deployment template, which indicates its location
      */
     public get documentId(): Uri {
         return this._documentId;
@@ -137,7 +147,10 @@ export abstract class DeploymentDocument {
         return this._jsonParseResult.getValueAtCharacterIndex(documentCharacterIndex, containsBehavior);
     }
 
-    public abstract findReferences(definition: INamedDefinition): ReferenceList;
+    /**
+     * Find all references in this document to the given named definition (which may or may not be in this document)
+     */
+    public abstract findReferencesToDefinition(definition: INamedDefinition): ReferenceList;
 
     /**
      * Provide commands for the given document and range.

--- a/src/ReferenceList.ts
+++ b/src/ReferenceList.ts
@@ -2,44 +2,48 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
+import { DeploymentDocument } from "./DeploymentDocument";
 import { assert } from "./fixed_assert";
 import { DefinitionKind } from "./INamedDefinition";
 import * as language from "./Language";
 import { nonNullValue } from "./util/nonNull";
 
+export interface IReference {
+    span: language.Span;
+    document: DeploymentDocument;
+}
+
 /**
  * A list of references that have been found.
  */
 export class ReferenceList {
-    constructor(private _type: DefinitionKind, private _spans: language.Span[] = []) {
+    constructor(private _type: DefinitionKind, private _refs: IReference[] = []) {
         nonNullValue(_type, "_type");
-        nonNullValue(_spans, "_spans");
+        nonNullValue(_refs, "_refs");
     }
 
     public get length(): number {
-        return this._spans.length;
+        return this._refs.length;
     }
 
-    public get spans(): language.Span[] {
-        return this._spans;
+    public get references(): IReference[] {
+        return this._refs;
     }
 
     public get kind(): DefinitionKind {
         return this._type;
     }
 
-    public add(span: language.Span): void {
-        assert(span);
-
-        this._spans.push(span);
+    public add(reference: IReference): void {
+        this._refs.push(reference);
     }
 
     public addAll(list: ReferenceList): void {
         assert(list);
         assert.deepStrictEqual(this._type, list.kind, "Cannot add references from a list of a different reference type.");
 
-        for (const span of list.spans) {
-            this.add(span);
+        for (const ref of list.references) {
+            this.add(ref);
         }
     }
 
@@ -48,8 +52,11 @@ export class ReferenceList {
 
         const result = new ReferenceList(this._type);
 
-        for (const span of this._spans) {
-            result.add(span.translate(movement));
+        for (const ref of this.references) {
+            result.add({
+                document: ref.document,
+                span: ref.span.translate(movement)
+            });
         }
 
         return result;

--- a/src/debugMarkStrings.ts
+++ b/src/debugMarkStrings.ts
@@ -14,6 +14,10 @@ export function __debugMarkPositionInString(
     charactersBeforeIndex: number = 45,
     charactersAfterPosition: number = 50
 ): string {
+    if (position >= text.length) {
+        const textAtEnd = `${text.slice(text.length - charactersAfterPosition)}<END(${text.length})>`;
+        return `${textAtEnd}...<CURSOR=${position}>`;
+    }
     const preTextIndex = position - charactersBeforeIndex;
     const preText = `${(preTextIndex > 0 ? "..." : "")}${text.slice(preTextIndex >= 0 ? preTextIndex : 0, position)}`;
 
@@ -36,6 +40,9 @@ export function __debugMarkRangeInString(
     charactersBeforeIndex: number = 25,
     charactersAfterPosition: number = 50
 ): string {
+    if (position >= text.length) {
+        return __debugMarkPositionInString(text, position, leftMarker + rightMarker, charactersBeforeIndex, charactersAfterPosition);
+    }
     const preTextIndex = position - charactersBeforeIndex;
     const preText = `${(preTextIndex > 0 ? "..." : "")}${text.slice(preTextIndex >= 0 ? preTextIndex : 0, position)}`;
 

--- a/src/parameterFiles/DeploymentParameters.ts
+++ b/src/parameterFiles/DeploymentParameters.ts
@@ -86,12 +86,15 @@ export class DeploymentParameters extends DeploymentDocument {
         return ParametersPositionContext.fromDocumentCharacterIndex(this, documentCharacterIndex, associatedDocument);
     }
 
-    public findReferences(definition: INamedDefinition): ReferenceList {
+    public findReferencesToDefinition(definition: INamedDefinition): ReferenceList {
         const results: ReferenceList = new ReferenceList(definition.definitionKind);
 
-        // The only reference possible is the definition itself (from the template file)
+        // The only reference possible in the parameter file is the parameter's value definition
         if (definition.nameValue) {
-            results.add(definition.nameValue.unquotedSpan);
+            const paramValue = this.getParameterValue(definition.nameValue.unquotedValue);
+            if (paramValue) {
+                results.add({ document: this, span: paramValue.nameValue.unquotedSpan });
+            }
         }
         return results;
     }

--- a/test/DeploymentTemplate.test.ts
+++ b/test/DeploymentTemplate.test.ts
@@ -49,7 +49,7 @@ suite("DeploymentTemplate", () => {
             return new ReferenceList(definitionKind, []);
         }
 
-        return dt.findReferences(definition!);
+        return dt.findReferencesToDefinition(definition!);
     }
 
     suite("constructor(string)", () => {
@@ -1057,7 +1057,7 @@ suite("DeploymentTemplate", () => {
             const list: ReferenceList = findReferences(dt, DefinitionKind.Parameter, "dontMatchMe", dt.topLevelScope);
             assert(list);
             assert.deepStrictEqual(list.kind, DefinitionKind.Parameter);
-            assert.deepStrictEqual(list.spans, []);
+            assert.deepStrictEqual(list.references, []);
         });
 
         test("with parameter type and matching parameter definition", () => {
@@ -1065,7 +1065,7 @@ suite("DeploymentTemplate", () => {
             const list: ReferenceList = findReferences(dt, DefinitionKind.Parameter, "pName", dt.topLevelScope);
             assert(list);
             assert.deepStrictEqual(list.kind, DefinitionKind.Parameter);
-            assert.deepStrictEqual(list.spans, [new Language.Span(19, 5)]);
+            assert.deepStrictEqual(list.references.map(r => r.span), [new Language.Span(19, 5)]);
         });
 
         test("with variable type and no matching variable definition", () => {
@@ -1073,7 +1073,7 @@ suite("DeploymentTemplate", () => {
             const list: ReferenceList = findReferences(dt, DefinitionKind.Variable, "dontMatchMe", dt.topLevelScope);
             assert(list);
             assert.deepStrictEqual(list.kind, DefinitionKind.Variable);
-            assert.deepStrictEqual(list.spans, []);
+            assert.deepStrictEqual(list.references.map(r => r.span), []);
         });
 
         test("with variable type and matching variable definition", () => {
@@ -1081,7 +1081,7 @@ suite("DeploymentTemplate", () => {
             const list: ReferenceList = findReferences(dt, DefinitionKind.Variable, "vName", dt.topLevelScope);
             assert(list);
             assert.deepStrictEqual(list.kind, DefinitionKind.Variable);
-            assert.deepStrictEqual(list.spans, [new Language.Span(18, 5)]);
+            assert.deepStrictEqual(list.references.map(r => r.span), [new Language.Span(18, 5)]);
         });
 
     }); // findReferences
@@ -1213,7 +1213,7 @@ suite("DeploymentTemplate", () => {
                     pc.getReferences();
                     pc.getSignatureHelp();
                     pc.tleInfo;
-                    pc.getReferenceSiteInfo();
+                    pc.getReferenceSiteInfo(true);
                     pc.getHoverInfo();
                     pc.getCompletionItems();
                 } catch (err) {

--- a/test/Reference.test.ts
+++ b/test/Reference.test.ts
@@ -5,10 +5,13 @@
 // tslint:disable:no-unused-expression  no-null-keyword max-func-body-length
 
 import * as assert from "assert";
-import { DefinitionKind, Language, ReferenceList } from "../extension.bundle";
+import { Uri } from "vscode";
+import { DefinitionKind, DeploymentTemplate, Language, ReferenceList } from "../extension.bundle";
 
 suite("Reference", () => {
     suite("List", () => {
+        const document = new DeploymentTemplate("", Uri.parse("fake"));
+
         suite("constructor(Reference.Type, Span[])", () => {
             test("with null type", () => {
                 // tslint:disable-next-line:no-any
@@ -28,36 +31,24 @@ suite("Reference", () => {
             test("with undefined spans", () => {
                 const list = new ReferenceList(DefinitionKind.Parameter, undefined);
                 assert.deepStrictEqual(list.kind, DefinitionKind.Parameter);
-                assert.deepStrictEqual(list.spans, []);
+                assert.deepStrictEqual(list.references, []);
                 assert.deepStrictEqual(list.length, 0);
             });
 
             test("with empty spans", () => {
                 const list = new ReferenceList(DefinitionKind.Parameter, []);
                 assert.deepStrictEqual(list.kind, DefinitionKind.Parameter);
-                assert.deepStrictEqual(list.spans, []);
+                assert.deepStrictEqual(list.references, []);
                 assert.deepStrictEqual(list.length, 0);
             });
 
             test("with non-empty spans", () => {
-                const list = new ReferenceList(DefinitionKind.Parameter, [new Language.Span(0, 1), new Language.Span(2, 3)]);
+                const list = new ReferenceList(DefinitionKind.Parameter, [
+                    { document, span: new Language.Span(0, 1) },
+                    { document, span: new Language.Span(2, 3) }]);
                 assert.deepStrictEqual(list.kind, DefinitionKind.Parameter);
-                assert.deepStrictEqual(list.spans, [new Language.Span(0, 1), new Language.Span(2, 3)]);
+                assert.deepStrictEqual(list.references.map(r => r.span), [new Language.Span(0, 1), new Language.Span(2, 3)]);
                 assert.deepStrictEqual(list.length, 2);
-            });
-        });
-
-        suite("add(Span)", () => {
-            test("with null", () => {
-                const list = new ReferenceList(DefinitionKind.Variable);
-                // tslint:disable-next-line:no-any
-                assert.throws(() => { list.add(<any>null); });
-            });
-
-            test("with undefined", () => {
-                const list = new ReferenceList(DefinitionKind.Variable);
-                // tslint:disable-next-line:no-any
-                assert.throws(() => { list.add(<any>undefined); });
             });
         });
 
@@ -78,7 +69,7 @@ suite("Reference", () => {
                 const list = new ReferenceList(DefinitionKind.Variable);
                 list.addAll(new ReferenceList(DefinitionKind.Variable));
                 assert.deepStrictEqual(list.length, 0);
-                assert.deepStrictEqual(list.spans, []);
+                assert.deepStrictEqual(list.references, []);
             });
 
             test("with empty list of a different type", () => {
@@ -88,8 +79,8 @@ suite("Reference", () => {
 
             test("with non-empty list", () => {
                 const list = new ReferenceList(DefinitionKind.Variable);
-                list.addAll(new ReferenceList(DefinitionKind.Variable, [new Language.Span(10, 20)]));
-                assert.deepStrictEqual(list.spans, [new Language.Span(10, 20)]);
+                list.addAll(new ReferenceList(DefinitionKind.Variable, [{ document, span: new Language.Span(10, 20) }]));
+                assert.deepStrictEqual(list.references.map(r => r.span), [new Language.Span(10, 20)]);
             });
         });
 
@@ -101,19 +92,19 @@ suite("Reference", () => {
             });
 
             test("with non-empty list", () => {
-                const list = new ReferenceList(DefinitionKind.Parameter, [new Language.Span(10, 20)]);
+                const list = new ReferenceList(DefinitionKind.Parameter, [{ document, span: new Language.Span(10, 20) }]);
                 const list2 = list.translate(17);
-                assert.deepStrictEqual(list2, new ReferenceList(DefinitionKind.Parameter, [new Language.Span(27, 20)]));
+                assert.deepStrictEqual(list2, new ReferenceList(DefinitionKind.Parameter, [{ document, span: new Language.Span(27, 20) }]));
             });
 
             test("with null movement", () => {
-                const list = new ReferenceList(DefinitionKind.Parameter, [new Language.Span(10, 20)]);
+                const list = new ReferenceList(DefinitionKind.Parameter, [{ document, span: new Language.Span(10, 20) }]);
                 // tslint:disable-next-line:no-any
                 assert.throws(() => { list.translate(<any>null); });
             });
 
             test("with undefined movement", () => {
-                const list = new ReferenceList(DefinitionKind.Parameter, [new Language.Span(10, 20)]);
+                const list = new ReferenceList(DefinitionKind.Parameter, [{ document, span: new Language.Span(10, 20) }]);
                 // tslint:disable-next-line:no-any
                 assert.throws(() => { list.translate(<any>undefined); });
             });

--- a/test/TLE.test.ts
+++ b/test/TLE.test.ts
@@ -2225,7 +2225,7 @@ suite("TLE", () => {
                 const dt = await parseTemplate(template);
                 const param = dt.topLevelScope.getParameterDefinition("pName")!;
                 assert(param);
-                const visitor = FindReferencesVisitor.visit(undefined, param, metadata);
+                const visitor = FindReferencesVisitor.visit(dt, undefined, param, metadata);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.references, new ReferenceList(DefinitionKind.Parameter));
             });
@@ -2235,7 +2235,7 @@ suite("TLE", () => {
                 const param = dt.topLevelScope.getParameterDefinition("pName")!;
                 assert(param);
                 // tslint:disable-next-line:no-any
-                const visitor = FindReferencesVisitor.visit(<any>undefined, param, metadata);
+                const visitor = FindReferencesVisitor.visit(dt, <any>undefined, param, metadata);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.references, new ReferenceList(DefinitionKind.Parameter));
             });
@@ -2245,11 +2245,11 @@ suite("TLE", () => {
                 const param = dt.topLevelScope.getParameterDefinition("pName")!;
                 assert(param);
                 const pr: TLE.ParseResult = parseExpressionWithScope(`"[parameters('pName')]"`, dt.topLevelScope);
-                const visitor = FindReferencesVisitor.visit(pr.expression, param, metadata);
+                const visitor = FindReferencesVisitor.visit(dt, pr.expression, param, metadata);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.references,
-                    new ReferenceList(DefinitionKind.Parameter, [new Language.Span(14, 5)]));
+                    new ReferenceList(DefinitionKind.Parameter, [{ document: dt, span: new Language.Span(14, 5) }]));
             });
         });
     });

--- a/test/TemplatePositionContext.test.ts
+++ b/test/TemplatePositionContext.test.ts
@@ -23,64 +23,64 @@ suite("TemplatePositionContext", () => {
     suite("fromDocumentLineAndColumnIndexes(DeploymentTemplate,number,number)", () => {
         test("with undefined deploymentTemplate", () => {
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(<any>undefined, 1, 2); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(<any>undefined, 1, 2, undefined); });
         });
 
         test("with undefined deploymentTemplate", () => {
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(<any>undefined, 1, 2); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(<any>undefined, 1, 2, undefined); });
         });
 
         test("with undefined documentLineIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, <any>undefined, 2); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, <any>undefined, 2, undefined); });
         });
 
         test("with undefined documentLineIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, <any>undefined, 2); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, <any>undefined, 2, undefined); });
         });
 
         test("with negative documentLineIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, -1, 2); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, -1, 2, undefined); });
         });
 
         test("with documentLineIndex equal to document line count", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             assert.deepStrictEqual(1, dt.lineCount);
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 1, 0); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 1, 0, undefined); });
         });
 
         test("with undefined documentColumnIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, <any>undefined); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, <any>undefined, undefined); });
         });
 
         test("with undefined documentColumnIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, <any>undefined); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, <any>undefined, undefined); });
         });
 
         test("with negative documentColumnIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, -2); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, -2, undefined); });
         });
 
         test("with documentColumnIndex greater than line length", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
-            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, 3); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 0, 3, undefined); });
         });
 
         test("with valid arguments", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             let documentLineIndex = 0;
             let documentColumnIndex = 2;
-            let pc = TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, documentLineIndex, documentColumnIndex);
+            let pc = TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, documentLineIndex, documentColumnIndex, undefined);
             assert.deepStrictEqual(new Language.Position(0, 2), pc.documentPosition);
             assert.deepStrictEqual(0, pc.documentLineIndex);
             assert.deepStrictEqual(2, pc.documentColumnIndex);
@@ -90,40 +90,40 @@ suite("TemplatePositionContext", () => {
     suite("fromDocumentCharacterIndex(DeploymentTemplate,number)", () => {
         test("with undefined deploymentTemplate", () => {
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(<any>undefined, 1); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(<any>undefined, 1, undefined); });
         });
 
         test("with undefined deploymentTemplate", () => {
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(<any>undefined, 1); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(<any>undefined, 1, undefined); });
         });
 
         test("with undefined documentCharacterIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, <any>undefined); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, <any>undefined, undefined); });
         });
 
         test("with undefined documentCharacterIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             // tslint:disable-next-line:no-any
-            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, <any>undefined); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, <any>undefined, undefined); });
         });
 
         test("with negative documentCharacterIndex", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
-            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, -1); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, -1, undefined); });
         });
 
         test("with documentCharacterIndex greater than the maximum character index", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
-            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, 3); });
+            assert.throws(() => { TemplatePositionContext.fromDocumentCharacterIndex(dt, 3, undefined); });
         });
 
         test("with valid arguments", () => {
             let dt = new DeploymentTemplate("{}", fakeId);
             let documentCharacterIndex = 2;
-            let pc = TemplatePositionContext.fromDocumentCharacterIndex(dt, documentCharacterIndex);
+            let pc = TemplatePositionContext.fromDocumentCharacterIndex(dt, documentCharacterIndex, undefined);
             assert.deepStrictEqual(2, pc.documentCharacterIndex);
         });
     });
@@ -131,24 +131,24 @@ suite("TemplatePositionContext", () => {
     suite("documentPosition", () => {
         test("with PositionContext from line and column indexes", () => {
             const dt = new DeploymentTemplate("{\n}", fakeId);
-            let pc = TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 1, 0);
+            let pc = TemplatePositionContext.fromDocumentLineAndColumnIndexes(dt, 1, 0, undefined);
             assert.deepStrictEqual(new Language.Position(1, 0), pc.documentPosition);
         });
 
         test("with PositionContext from characterIndex", () => {
-            let pc = TemplatePositionContext.fromDocumentCharacterIndex(new DeploymentTemplate("{\n}", fakeId), 2);
+            let pc = TemplatePositionContext.fromDocumentCharacterIndex(new DeploymentTemplate("{\n}", fakeId), 2, undefined);
             assert.deepStrictEqual(new Language.Position(1, 0), pc.documentPosition);
         });
     });
 
     suite("documentCharacterIndex", () => {
         test("with PositionContext from line and column indexes", () => {
-            let pc = TemplatePositionContext.fromDocumentLineAndColumnIndexes(new DeploymentTemplate("{\n}", fakeId), 1, 0);
+            let pc = TemplatePositionContext.fromDocumentLineAndColumnIndexes(new DeploymentTemplate("{\n}", fakeId), 1, 0, undefined);
             assert.deepStrictEqual(2, pc.documentCharacterIndex);
         });
 
         test("with PositionContext from characterIndex", () => {
-            let pc = TemplatePositionContext.fromDocumentCharacterIndex(new DeploymentTemplate("{\n}", fakeId), 2);
+            let pc = TemplatePositionContext.fromDocumentCharacterIndex(new DeploymentTemplate("{\n}", fakeId), 2, undefined);
             assert.deepStrictEqual(2, pc.documentCharacterIndex);
         });
     });
@@ -1454,7 +1454,7 @@ suite("TemplatePositionContext", () => {
 
     suite("parameterDefinition", () => {
         async function getParameterDefinitionIfAtReference(pc: TemplatePositionContext): Promise<IParameterDefinition | undefined> {
-            const refInfo: IReferenceSite | undefined = pc.getReferenceSiteInfo();
+            const refInfo: IReferenceSite | undefined = pc.getReferenceSiteInfo(false);
             if (refInfo && refInfo.definition.definitionKind === "Parameter") {
                 return <IParameterDefinition>refInfo.definition;
             }
@@ -1504,7 +1504,7 @@ suite("TemplatePositionContext", () => {
 
     suite("variableDefinition", () => {
         function getVariableDefinitionIfAtReference(pc: TemplatePositionContext): IVariableDefinition | undefined {
-            const refInfo: IReferenceSite | undefined = pc.getReferenceSiteInfo();
+            const refInfo: IReferenceSite | undefined = pc.getReferenceSiteInfo(false);
             if (refInfo && isVariableDefinition(refInfo.definition)) {
                 return refInfo.definition;
             }

--- a/test/UserFunctions.test.ts
+++ b/test/UserFunctions.test.ts
@@ -1361,7 +1361,7 @@ suite("User functions", () => {
             expectedDefinitionStart: number
         ): Promise<void> {
             const pc = dt.getContextFromDocumentCharacterIndex(cursorIndex, undefined);
-            const refInfo: IReferenceSite = pc.getReferenceSiteInfo()!;
+            const refInfo: IReferenceSite = pc.getReferenceSiteInfo(false)!;
             assert(refInfo, "Expected non-null IReferenceSite");
 
             assert.deepStrictEqual(refInfo.definition.definitionKind, expectedReferenceKind);

--- a/test/support/testGetReferences.ts
+++ b/test/support/testGetReferences.ts
@@ -22,7 +22,7 @@ export async function testGetReferences(dt: DeploymentTemplate, cursorIndex: num
     const references: ReferenceList = pc.getReferences()!;
     assert(references, "Expected non-empty list of references");
 
-    const indices = references.spans.map(r => r.startIndex).sort();
+    const indices = references.references.map(r => r.span.startIndex).sort();
     expectedReferenceIndices = expectedReferenceIndices.sort();
 
     assert.deepStrictEqual(indices, expectedReferenceIndices);


### PR DESCRIPTION
Builds on top of #555 (For 0.10.0: Support completions, code actions, validation etc in parameter files (part 1))

Second half of #566 
Adds the following:
- Show References in template or params file should show uses/definition from in associated file (#518)
- Show References on params in template file - show parameter value in params file
- Rename parameter in template or params file should rename in associated file (#516)