### PR TITLE
Use dotnet 3.0.3, support TLS 2/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "vscode-azurearmtools" extension will be documented in this file.
 
+## Version 0.9.1 (2020-04-17)
+
+### Fixed
+
+- Update to 3.0.3 of .NET Core runtime and update install scripts
+
 ## Version 0.9.0 (2020-04-14)
 
 ### Added

--- a/assets/install scripts/dotnet-install.ps1
+++ b/assets/install scripts/dotnet-install.ps1
@@ -238,6 +238,7 @@ function GetHTTPResponse([Uri] $Uri)
             # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
             # 20 minutes allows it to work over much slower connections.
             $HttpClient.Timeout = New-TimeSpan -Minutes 20
+            [Net.ServicePointManager]::SecurityProtocol = 'Tls12, Tls13'
             $Response = $HttpClient.GetAsync("${Uri}${FeedCredential}").Result
             if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode))) {
                  # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.

--- a/assets/install scripts/dotnet-install.ps1
+++ b/assets/install scripts/dotnet-install.ps1
@@ -80,42 +80,42 @@
 #>
 [cmdletbinding()]
 param(
-    [string]$Channel = "LTS",
-    [string]$Version = "Latest",
-    [string]$JSonFile,
-    [string]$InstallDir = "<auto>",
-    [string]$Architecture = "<auto>",
-    [ValidateSet("dotnet", "aspnetcore", "windowsdesktop", IgnoreCase = $false)]
-    [string]$Runtime,
-    [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
-    [switch]$SharedRuntime,
-    [switch]$DryRun,
-    [switch]$NoPath,
-    [string]$AzureFeed = "https://dotnetcli.azureedge.net/dotnet",
-    [string]$UncachedFeed = "https://dotnetcli.blob.core.windows.net/dotnet",
-    [string]$FeedCredential,
-    [string]$ProxyAddress,
-    [switch]$ProxyUseDefaultCredentials,
-    [switch]$SkipNonVersionedFiles,
-    [switch]$NoCdn
+   [string]$Channel="LTS",
+   [string]$Version="Latest",
+   [string]$JSonFile,
+   [string]$InstallDir="<auto>",
+   [string]$Architecture="<auto>",
+   [ValidateSet("dotnet", "aspnetcore", "windowsdesktop", IgnoreCase = $false)]
+   [string]$Runtime,
+   [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
+   [switch]$SharedRuntime,
+   [switch]$DryRun,
+   [switch]$NoPath,
+   [string]$AzureFeed="https://dotnetcli.azureedge.net/dotnet",
+   [string]$UncachedFeed="https://dotnetcli.blob.core.windows.net/dotnet",
+   [string]$FeedCredential,
+   [string]$ProxyAddress,
+   [switch]$ProxyUseDefaultCredentials,
+   [switch]$SkipNonVersionedFiles,
+   [switch]$NoCdn
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
-$ProgressPreference = "SilentlyContinue"
+$ErrorActionPreference="Stop"
+$ProgressPreference="SilentlyContinue"
 
 if ($NoCdn) {
     $AzureFeed = $UncachedFeed
 }
 
-$BinFolderRelativePath = ""
+$BinFolderRelativePath=""
 
 if ($SharedRuntime -and (-not $Runtime)) {
     $Runtime = "dotnet"
 }
 
 # example path with regex: shared/1.0.0-beta-12345/somepath
-$VersionRegEx = "/\d+\.\d+[^/]+/"
+$VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles = !$SkipNonVersionedFiles
 
 function Say($str) {
@@ -184,7 +184,7 @@ function Get-Version-Info-From-Version-Text([string]$VersionText) {
 
     $VersionInfo = @{
         CommitHash = $(if ($Data.Count -gt 1) { $Data[0] })
-        Version    = $Data[-1] # last line is always the version number.
+        Version = $Data[-1] # last line is always the version number.
     }
     return $VersionInfo
 }
@@ -199,64 +199,64 @@ function Load-Assembly([string] $Assembly) {
     }
 }
 
-function GetHTTPResponse([Uri] $Uri) {
+function GetHTTPResponse([Uri] $Uri)
+{
     Invoke-With-Retry(
-        {
+    {
 
-            $HttpClient = $null
+        $HttpClient = $null
 
-            try {
-                # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
-                Load-Assembly -Assembly System.Net.Http
+        try {
+            # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
+            Load-Assembly -Assembly System.Net.Http
 
-                if (-not $ProxyAddress) {
-                    try {
-                        # Despite no proxy being explicitly specified, we may still be behind a default proxy
-                        $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
-                        if ($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
-                            $ProxyAddress = $DefaultProxy.GetProxy($Uri).OriginalString
-                            $ProxyUseDefaultCredentials = $true
-                        }
+            if(-not $ProxyAddress) {
+                try {
+                    # Despite no proxy being explicitly specified, we may still be behind a default proxy
+                    $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
+                    if($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
+                        $ProxyAddress = $DefaultProxy.GetProxy($Uri).OriginalString
+                        $ProxyUseDefaultCredentials = $true
                     }
-                    catch {
-                        # Eat the exception and move forward as the above code is an attempt
-                        #    at resolving the DefaultProxy that may not have been a problem.
-                        $ProxyAddress = $null
-                        Say-Verbose("Exception ignored: $_.Exception.Message - moving forward...")
-                    }
-                }
-
-                if ($ProxyAddress) {
-                    $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
-                    $HttpClientHandler.Proxy = New-Object System.Net.WebProxy -Property @{Address = $ProxyAddress; UseDefaultCredentials = $ProxyUseDefaultCredentials }
-                    $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
-                }
-                else {
-
-                    $HttpClient = New-Object System.Net.Http.HttpClient
-                }
-                # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
-                # 20 minutes allows it to work over much slower connections.
-                $HttpClient.Timeout = New-TimeSpan -Minutes 20
-                $Response = $HttpClient.GetAsync("${Uri}${FeedCredential}").Result
-                if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode))) {
-                    # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
-                    $ErrorMsg = "Failed to download $Uri."
-                    if ($Response -ne $null) {
-                        $ErrorMsg += "  $Response"
-                    }
-
-                    throw $ErrorMsg
-                }
-
-                return $Response
-            }
-            finally {
-                if ($HttpClient -ne $null) {
-                    $HttpClient.Dispose()
+                } catch {
+                    # Eat the exception and move forward as the above code is an attempt
+                    #    at resolving the DefaultProxy that may not have been a problem.
+                    $ProxyAddress = $null
+                    Say-Verbose("Exception ignored: $_.Exception.Message - moving forward...")
                 }
             }
-        })
+
+            if($ProxyAddress) {
+                $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
+                $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress;UseDefaultCredentials=$ProxyUseDefaultCredentials}
+                $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
+            }
+            else {
+
+                $HttpClient = New-Object System.Net.Http.HttpClient
+            }
+            # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
+            # 20 minutes allows it to work over much slower connections.
+            $HttpClient.Timeout = New-TimeSpan -Minutes 20
+            $Response = $HttpClient.GetAsync("${Uri}${FeedCredential}").Result
+            if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode))) {
+                 # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
+                $ErrorMsg = "Failed to download $Uri."
+                if ($Response -ne $null) {
+                    $ErrorMsg += "  $Response"
+                }
+
+                throw $ErrorMsg
+            }
+
+             return $Response
+        }
+        finally {
+             if ($HttpClient -ne $null) {
+                $HttpClient.Dispose()
+            }
+        }
+    })
 }
 
 function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Coherent) {
@@ -495,7 +495,7 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
             if (($PathWithVersion -eq $null) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
                 $DestinationPath = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $entry.FullName)
                 $DestinationDir = Split-Path -Parent $DestinationPath
-                $OverrideFiles = $OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
+                $OverrideFiles=$OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
                 if ((-Not $DestinationPath.EndsWith("\")) -And $OverrideFiles) {
                     New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
                     [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $DestinationPath, $OverrideNonVersionedFiles)
@@ -546,8 +546,7 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
         if (-Not $env:path.Contains($SuffixedBinPath)) {
             Say "Adding to current process PATH: `"$BinPath`". Note: This change will not be visible if PowerShell was run as a child process."
             $env:path = $SuffixedBinPath + $env:path
-        }
-        else {
+        } else {
             Say-Verbose "Current process PATH already contains `"$BinPath`""
         }
     }
@@ -573,14 +572,14 @@ if ($DryRun) {
     }
     $RepeatableCommand = ".\$ScriptName -Version `"$SpecificVersion`" -InstallDir `"$InstallRoot`" -Architecture `"$CLIArchitecture`""
     if ($Runtime -eq "dotnet") {
-        $RepeatableCommand += " -Runtime `"dotnet`""
+       $RepeatableCommand+=" -Runtime `"dotnet`""
     }
     elseif ($Runtime -eq "aspnetcore") {
-        $RepeatableCommand += " -Runtime `"aspnetcore`""
+       $RepeatableCommand+=" -Runtime `"aspnetcore`""
     }
     foreach ($key in $MyInvocation.BoundParameters.Keys) {
-        if (-not (@("Architecture", "Channel", "DryRun", "InstallDir", "Runtime", "SharedRuntime", "Version") -contains $key)) {
-            $RepeatableCommand += " -$key `"$($MyInvocation.BoundParameters[$key])`""
+        if (-not (@("Architecture","Channel","DryRun","InstallDir","Runtime","SharedRuntime","Version") -contains $key)) {
+            $RepeatableCommand+=" -$key `"$($MyInvocation.BoundParameters[$key])`""
         }
     }
     Say "Repeatable invocation: $RepeatableCommand"

--- a/assets/install scripts/dotnet-install.sh
+++ b/assets/install scripts/dotnet-install.sh
@@ -728,11 +728,12 @@ downloadcurl() {
     # Append feed_credential as late as possible before calling curl to avoid logging feed_credential
     remote_path="${remote_path}${feed_credential}"
 
+    local curl_options="--retry 20 --retry-delay 2 --connect-timeout 15 -sSL -f --create-dirs "
     local failed=false
     if [ -z "$out_path" ]; then
-        curl --retry 10 -sSL -f --create-dirs "$remote_path" || failed=true
+        curl $curl_options "$remote_path" || failed=true
     else
-        curl --retry 10 -sSL -f --create-dirs -o "$out_path" "$remote_path" || failed=true
+        curl $curl_options -o "$out_path" "$remote_path" || failed=true
     fi
     if [ "$failed" = true ]; then
         say_verbose "Curl download failed"
@@ -748,12 +749,12 @@ downloadwget() {
 
     # Append feed_credential as late as possible before calling wget to avoid logging feed_credential
     remote_path="${remote_path}${feed_credential}"
-
+    local wget_options="--tries 20 --waitretry 2 --connect-timeout 15 "
     local failed=false
     if [ -z "$out_path" ]; then
-        wget -q --tries 10 -O - "$remote_path" || failed=true
+        wget -q $wget_options -O - "$remote_path" || failed=true
     else
-        wget --tries 10 -O "$out_path" "$remote_path" || failed=true
+        wget $wget_options -O "$out_path" "$remote_path" || failed=true
     fi
     if [ "$failed" = true ]; then
         say_verbose "Wget download failed"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azurerm-vscode-tools",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "azurerm-vscode-tools",
     "displayName": "Azure Resource Manager (ARM) Tools",
     "description": "Language server, editing tools and snippets for Azure Resource Manager (ARM) template files.",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "publisher": "msazurermtools",
     "config": {
         "ARM_LANGUAGE_SERVER_NUGET_VERSION": "3.0.0-preview.20214.4"

--- a/src/acquisition/DotnetCoreAcquisitionWorker.ts
+++ b/src/acquisition/DotnetCoreAcquisitionWorker.ts
@@ -33,7 +33,7 @@ export class DotnetCoreAcquisitionWorker {
         '2.0': '2.0.9',
         2.1: '2.1.11',
         2.2: '2.2.5',
-        '3.0': '3.0.2'
+        '3.0': '3.0.3'
     };
 
     private acquisitionPromises: { [version: string]: Promise<string> | undefined };


### PR DESCRIPTION
The first commit updates the install scripts to the latest version, although it's mostly whitespace changes.  It also uses 3.0.3 instead of 3.0.2
The second commit attempts to add the TLS 2/3 fix from https://github.com/microsoft/vscode-azurearmtools/issues/598#issuecomment-614855482 and https://github.com/microsoft/vscode-azurearmtools/issues/598#issuecomment-614708618