### PR TITLE
Require vscode 1.41.0 to match dotnet install extension requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "icon": "AzureRMTools128x128.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.31.0"
+        "vscode": "^1.41.0"
     },
     "preview": true,
     "activationEvents": [


### PR DESCRIPTION
Fixes #614 