### PR TITLE
Support TLS12/13

### DIFF
--- a/assets/install scripts/dotnet-install.cmd
+++ b/assets/install scripts/dotnet-install.cmd
@@ -1,2 +1,2 @@
 @ECHO OFF
-PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0dotnet-install.ps1' %*; exit $LASTEXITCODE"
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; [System.Net.ServicePointManager]::SecurityProtocol=[System.Net.SecurityProtocolType]::Tls12+[System.Net.SecurityProtocolType]::Tls13; & '%~dp0dotnet-install.ps1' %*; exit $LASTEXITCODE"


### PR DESCRIPTION
The problem as I understand it is that machines with .NET 4.5 don't have TLS1.2 enabled by default (and something changed in Azure enforcing certain security requirements).