### PR TITLE
Fix issues with Insert item 670

### DIFF
--- a/package.json
+++ b/package.json
@@ -396,102 +396,102 @@
                 {
                     "$comment": "============= Treeview commands =============",
                     "command": "azurerm-vscode-tools.sortFunctions",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortOutputs",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortParameters",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortResources",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortVariables",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertParameter",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertVariable",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertOutput",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertFunction",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertResource",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources@\\d/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortFunctions",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions1",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions@1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortOutputs",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs1",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs@1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortParameters",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters1",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters@1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortResources",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources1",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources@1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortVariables",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables1",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables@1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertParameter",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters@\\d/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertVariable",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables@\\d/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertOutput",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs@\\d/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertFunction",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions@\\d/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertResource",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources.*/",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources@\\d/",
                     "group": "inline"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -396,102 +396,102 @@
                 {
                     "$comment": "============= Treeview commands =============",
                     "command": "azurerm-vscode-tools.sortFunctions",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortOutputs",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortParameters",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortResources",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortVariables",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertParameter",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertVariable",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertOutput",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertFunction",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertResource",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources.*/",
                     "group": "arm-template"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortFunctions",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortOutputs",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortParameters",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortResources",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.sortVariables",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables1",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertParameter",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == parameters",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /parameters.*/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertVariable",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == variables",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /variables.*/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertOutput",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == outputs",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /outputs.*/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertFunction",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == functions",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /functions.*/",
                     "group": "inline"
                 },
                 {
                     "command": "azurerm-vscode-tools.insertResource",
-                    "when": "view == azurerm-vscode-tools.template-outline && viewItem == resources",
+                    "when": "view == azurerm-vscode-tools.template-outline && viewItem =~ /resources.*/",
                     "group": "inline"
                 }
             ],

--- a/src/Treeview.ts
+++ b/src/Treeview.ts
@@ -294,13 +294,14 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
 
     /**
      * Retrieves the context value of the tree item, which can be used in the "where" clause of an view/item/context
-     * menu, as viewItem == <contextValue>
+     * menu, as viewItem == <contextValue>.
+     * @return A string with the context value (example "resources@2") or undefined
      */
     private getContextValue(elementInfo: IElementInfo): string | undefined {
         let element = elementInfo.current.level === 1 ? elementInfo.current : elementInfo.root;
         const keyNode = this.tree && this.tree.getValueAtCharacterIndex(element.key.start, Contains.strict);
         if (keyNode instanceof Json.StringValue) {
-            return `${keyNode.unquotedValue}${elementInfo.current.level}`;
+            return `${keyNode.unquotedValue}@${elementInfo.current.level}`;
         }
         return undefined;
     }

--- a/src/Treeview.ts
+++ b/src/Treeview.ts
@@ -300,7 +300,7 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<string> {
         let element = elementInfo.current.level === 1 ? elementInfo.current : elementInfo.root;
         const keyNode = this.tree && this.tree.getValueAtCharacterIndex(element.key.start, Contains.strict);
         if (keyNode instanceof Json.StringValue) {
-            return keyNode.unquotedValue;
+            return `${keyNode.unquotedValue}${elementInfo.current.level}`;
         }
         return undefined;
     }

--- a/src/insertItem.ts
+++ b/src/insertItem.ts
@@ -432,7 +432,7 @@ export class InsertItem {
         let newCursorPosition = this.getCursorPositionForInsertResource(textEditor, index, prepend);
         textEditor.selection = new vscode.Selection(newCursorPosition, newCursorPosition);
         await commands.executeCommand('editor.action.insertSnippet', { name: resource.label });
-        textEditor.revealRange(new vscode.Range(newCursorPosition, newCursorPosition), vscode.TextEditorRevealType.Default);
+        textEditor.revealRange(new vscode.Range(newCursorPosition, newCursorPosition), vscode.TextEditorRevealType.AtTop);
     }
 
     private getCursorPositionForInsertResource(textEditor: vscode.TextEditor, index: number, prepend: string): vscode.Position {
@@ -512,7 +512,8 @@ export class InsertItem {
         text = this.formatText(text, textEditor);
         let pos = textEditor.document.positionAt(index);
         await textEditor.edit(builder => builder.insert(pos, text));
-        textEditor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.Default);
+        let endPos = textEditor.document.positionAt(index + text.length);
+        textEditor.revealRange(new vscode.Range(pos, endPos), vscode.TextEditorRevealType.Default);
         if (setCursor && text.lastIndexOf(insertCursorText) >= 0) {
             let insertedText = textEditor.document.getText(new vscode.Range(pos, textEditor.document.positionAt(index + text.length)));
             let cursorPos = insertedText.lastIndexOf(insertCursorText);

--- a/src/sortTemplate.ts
+++ b/src/sortTemplate.ts
@@ -81,7 +81,7 @@ export async function sortTemplate(template: DeploymentTemplate | undefined, sec
  */
 async function showSortingResultMessage(sortAction: () => Promise<boolean>, part: string): Promise<void> {
     let didSorting = await sortAction();
-    let message = didSorting ? `${part} section was sorted` : `Nothing in ${part.toLowerCase()} needed sorting`;
+    let message = didSorting ? `"${part}" section was sorted` : `Nothing in "${part.toLowerCase()}" needed sorting`;
     vscode.window.showInformationMessage(message);
 }
 

--- a/src/sortTemplate.ts
+++ b/src/sortTemplate.ts
@@ -72,12 +72,25 @@ export async function sortTemplate(template: DeploymentTemplate | undefined, sec
     }
 }
 
+/**
+ * Shows an information message on the result of the sorting.
+ * Could be "Resources section was sorted" or "Nothing in resources needed sorting"
+ * @param sortAction The action that is invoked to do the sorting
+ * @param part The part of the template (example: Resources)
+ * @returns A promise of void
+ */
 async function showSortingResultMessage(sortAction: () => Promise<boolean>, part: string): Promise<void> {
     let didSorting = await sortAction();
-    let message = didSorting ? `${part} were sorted` : `No ${part.toLowerCase()} needed sorting`;
+    let message = didSorting ? `${part} section was sorted` : `Nothing in ${part.toLowerCase()} needed sorting`;
     vscode.window.showInformationMessage(message);
 }
 
+/**
+ * Sorts the outputs.
+ * @param template The template to be sorted
+ * @param textEditor The current text editor
+ * @returns True if order was changed when sorting, otherwise false
+ */
 async function sortOutputs(template: DeploymentTemplate, textEditor: vscode.TextEditor): Promise<boolean> {
     let rootValue = template.topLevelValue;
     if (!rootValue) {
@@ -90,6 +103,12 @@ async function sortOutputs(template: DeploymentTemplate, textEditor: vscode.Text
     return false;
 }
 
+/**
+ * Sorts the resources and first level of their sub resources.
+ * @param  template The deployment template to be sorted
+ * @param textEditor The current text editor
+ * @returns True if the order was changed when sorting, otherwise false
+ */
 async function sortResources(template: DeploymentTemplate, textEditor: vscode.TextEditor): Promise<boolean> {
     let rootValue = template.topLevelValue;
     if (!rootValue) {
@@ -105,6 +124,12 @@ async function sortResources(template: DeploymentTemplate, textEditor: vscode.Te
     return false;
 }
 
+/**
+ * Sorts the top-level items (parameters, variables, functions, resources and outputs).
+ * @param template The deployment template to be sorted
+ * @param textEditor The current text editor
+ * @returns True if order was changed after sorting, otherwise false
+ */
 async function sortTopLevel(template: DeploymentTemplate, textEditor: vscode.TextEditor): Promise<boolean> {
     let rootValue = template.topLevelValue;
     if (!rootValue) {
@@ -113,18 +138,36 @@ async function sortTopLevel(template: DeploymentTemplate, textEditor: vscode.Tex
     return await sortGeneric<Json.Property>(rootValue.properties, x => getTopLevelOrder(x.nameValue.quotedValue), x => x.span, template, textEditor);
 }
 
+/**
+ * Sort the variables.
+ * @param template The deployment template to be sorted
+ * @param textEditor The current text editor
+ * @returns True if order was changed after sorting, otherwise false
+ */
 async function sortVariables(template: DeploymentTemplate, textEditor: vscode.TextEditor): Promise<boolean> {
     return await sortGeneric<IVariableDefinition>(
         template.topLevelScope.variableDefinitions,
         x => x.nameValue.quotedValue, x => x.span, template, textEditor);
 }
 
+/**
+ * Sorts the parameters.
+ * @param template The deployment template to be sorted
+ * @param textEditor The current text editor
+ * @returns True if order was changed after sorting, otherwise false
+ */
 async function sortParameters(template: DeploymentTemplate, textEditor: vscode.TextEditor): Promise<boolean> {
     return await sortGeneric<IParameterDefinition>(
         template.topLevelScope.parameterDefinitions,
         x => x.nameValue.quotedValue, x => x.fullSpan, template, textEditor);
 }
 
+/**
+ * Sorts the functions and namespaces.
+ * @param template The deployment template to be sorted
+ * @param textEditor The current text editor
+ * @returns True if order was changed after sorting, otherwise false
+ */
 async function sortFunctions(template: DeploymentTemplate, textEditor: vscode.TextEditor): Promise<boolean> {
     let didSort1 = await sortGenericDeep<UserFunctionNamespaceDefinition, UserFunctionDefinition>(
         template.topLevelScope.namespaceDefinitions,

--- a/src/sortTemplate.ts
+++ b/src/sortTemplate.ts
@@ -65,7 +65,7 @@ export async function sortTemplate(template: DeploymentTemplate | undefined, sec
             await showSortingResultMessage(() => sortVariables(template, textEditor), "Variables");
             break;
         case TemplateSectionType.TopLevel:
-            await showSortingResultMessage(() => sortTopLevel(template, textEditor), "Top level items");
+            await showSortingResultMessage(() => sortTopLevel(template, textEditor), "Top-level items");
             break;
         default:
             assertNever(sectionType);


### PR DESCRIPTION
This PR tries to fix the issues mentioned in #670 

-  P1: After inserting, the location of the cursor should get revealed (currently the entire span gets revealed?)
- P2: Now that we have a simple icon button to sort individual sections, it's a little disconcerting if I click, say, on the parameters' sort button and it says "Done sorting template!". It would be better to be more specific "Parameters were sorted". Ideally it would say "No parameters needed sorting" if appropriate.