### PR TITLE
Logging about inserting or sorting not necessary.

### DIFF
--- a/src/insertItem.ts
+++ b/src/insertItem.ts
@@ -13,7 +13,6 @@ import { IActionContext, IAzureUserInput } from "vscode-azureextensionui";
 import { Json, templateKeys } from "../extension.bundle";
 import { assetsPath } from "./constants";
 import { DeploymentTemplate } from "./DeploymentTemplate";
-import { ext } from './extensionVariables';
 import { TemplateSectionType } from "./TemplateSectionType";
 import { assertNever } from './util/assertNever';
 
@@ -104,7 +103,6 @@ export class InsertItem {
         if (!template) {
             return;
         }
-        ext.outputChannel.appendLine("Insert item");
         switch (sectionType) {
             case TemplateSectionType.Functions:
                 await this.insertFunction(template, textEditor, context);

--- a/src/sortTemplate.ts
+++ b/src/sortTemplate.ts
@@ -7,7 +7,6 @@ import * as vscode from "vscode";
 import { Language } from "../extension.bundle";
 import { templateKeys } from './constants';
 import { DeploymentTemplate } from "./DeploymentTemplate";
-import { ext } from './extensionVariables';
 import { IParameterDefinition } from './IParameterDefinition';
 import * as Json from "./JSON";
 import * as language from "./Language";
@@ -47,7 +46,6 @@ export async function sortTemplate(template: DeploymentTemplate | undefined, sec
     if (!template) {
         return;
     }
-    ext.outputChannel.appendLine("Sorting template");
     switch (sectionType) {
         case TemplateSectionType.Functions:
             await showSortingResultMessage(() => sortFunctions(template, textEditor), "Functions");


### PR DESCRIPTION
We generally keep the output log clean except for warnings/errors or important debugging info.  So removing the "Sorting" and "Insert item" output.

Fixes #735 
Fixes #733 
Fixes #734 