### PR TITLE
Fix warnings for nested scopes and warn about inaccessible inner scope members

### DIFF
--- a/src/DeploymentTemplate.ts
+++ b/src/DeploymentTemplate.ts
@@ -255,25 +255,29 @@ export class DeploymentTemplate extends DeploymentDocument {
             + `If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.`;
 
         for (const scope of this.allScopes.filter(ts => ts.scopeKind === TemplateScopeKind.NestedDeploymentWithOuterScope)) {
-            const parameters = scope.rootObject?.getProperty(templateKeys.parameters)?.value;
+            const parameters = getPropertyValueOfScope(templateKeys.parameters);
             // tslint:disable-next-line: strict-boolean-expressions
             if (!!parameters?.asObjectValue?.properties?.length) {
                 warnings.push(
                     new language.Issue(parameters.span, warningMessage, language.IssueKind.inaccessibleNestedScopeMembers));
             }
 
-            const variables = scope.rootObject?.getProperty(templateKeys.variables)?.value;
+            const variables = getPropertyValueOfScope(templateKeys.variables);
             // tslint:disable-next-line: strict-boolean-expressions
             if (!!variables?.asObjectValue?.properties.length) {
                 warnings.push(
                     new language.Issue(variables.span, warningMessage, language.IssueKind.inaccessibleNestedScopeMembers));
             }
 
-            const namespaces = scope.rootObject?.getProperty(templateKeys.functions)?.value;
+            const namespaces = getPropertyValueOfScope(templateKeys.functions);
             // tslint:disable-next-line: strict-boolean-expressions
             if (!!namespaces?.asArrayValue?.elements.length) {
                 warnings.push(
                     new language.Issue(namespaces.span, warningMessage, language.IssueKind.inaccessibleNestedScopeMembers));
+            }
+
+            function getPropertyValueOfScope(propertyName: string): Json.Value | undefined {
+                return scope.rootObject?.getProperty(propertyName)?.value;
             }
         }
 

--- a/src/IParameterDefinition.ts
+++ b/src/IParameterDefinition.ts
@@ -25,6 +25,4 @@ export interface IParameterDefinition extends INamedDefinition {
     // Description and defaultValue are only supported for top-level parameters
     description: string | undefined;
     defaultValue: Json.Value | undefined;
-
-    //parentContext: string | undefined; //asdf
 }

--- a/src/IParameterDefinition.ts
+++ b/src/IParameterDefinition.ts
@@ -25,4 +25,6 @@ export interface IParameterDefinition extends INamedDefinition {
     // Description and defaultValue are only supported for top-level parameters
     description: string | undefined;
     defaultValue: Json.Value | undefined;
+
+    //parentContext: string | undefined; //asdf
 }

--- a/src/Language.ts
+++ b/src/Language.ts
@@ -256,6 +256,7 @@ export enum IssueKind {
     undefinedVar = "undefinedVar",
     varInUdf = "varInUdf",
     undefinedVarProp = "undefinedVarProp",
+    inaccessibleNestedScopeMembers = "inaccessibleNestedScopeMembers",
 
     // Parameter file issues
     params_missingRequiredParam = "params_missingRequiredParam",

--- a/src/TemplateScope.ts
+++ b/src/TemplateScope.ts
@@ -32,6 +32,15 @@ export abstract class TemplateScope {
 
     public readonly abstract scopeKind: TemplateScopeKind;
 
+    // CONSIDER: Better design. Split out resources from params/vars/functions, or separate
+    //   concept of deployment from concept of scope?
+    /**
+     * Indicates whether this scope's params, vars and namespaces are unique.
+     * False if it shares its members with its parents.
+     * Note that resources are always unique for a scope.
+     */
+    public readonly hasUniqueParamsVarsAndFunctions: boolean = true;
+
     // undefined means not supported in this context
     protected getParameterDefinitions(): IParameterDefinition[] | undefined {
         // undefined means not supported in this context
@@ -85,9 +94,13 @@ export abstract class TemplateScope {
             }
         }
 
-        for (let namespace of this.namespaceDefinitions) {
-            for (let member of namespace.members) {
-                scopes.push(member.scope);
+        // If it's not unique, we'll end up getting the parent's function definitions
+        // instead of our own
+        if (this.hasUniqueParamsVarsAndFunctions) {
+            for (let namespace of this.namespaceDefinitions) {
+                for (let member of namespace.members) {
+                    scopes.push(member.scope);
+                }
             }
         }
 

--- a/src/deploymentTemplateCodeLenses.ts
+++ b/src/deploymentTemplateCodeLenses.ts
@@ -93,7 +93,7 @@ export class ParameterDefinitionCodeLens extends ResolvableCodeLens {
             } else if (defaultValueAsString !== undefined) {
                 title = `Using default value: ${defaultValueAsString}`;
             } else {
-                title = "No value found";
+                title = "$(warning) No value found";
             }
 
             if (title.length > this._maxCharactersInValue) {

--- a/src/templateScopes.ts
+++ b/src/templateScopes.ts
@@ -265,6 +265,9 @@ export class NestedTemplateOuterScope extends TemplateScope {
 
     public readonly scopeKind: TemplateScopeKind = TemplateScopeKind.NestedDeploymentWithOuterScope;
 
+    // Shares its members with its parent
+    public readonly hasUniqueParamsVarsAndFunctions: boolean = false;
+
     protected getParameterDefinitions(): IParameterDefinition[] | undefined {
         return this.parentScope.parameterDefinitions;
     }

--- a/test/DeploymentTemplate.CodeLenses.test.ts
+++ b/test/DeploymentTemplate.CodeLenses.test.ts
@@ -195,11 +195,11 @@ suite("DeploymentTemplate code lenses", () => {
         createParamLensTest('requiredInt', '123', 'Value: 123');
         createParamLensTest('requiredInt', '-123', 'Value: -123');
         createParamLensTest('optionalInt', undefined, 'Using default value: 123');
-        createParamLensTest('requiredInt', undefined, 'No value found');
+        createParamLensTest('requiredInt', undefined, '$(warning) No value found');
 
         createParamLensTest('requiredString', '"def"', 'Value: "def"');
         createParamLensTest('optionalString', undefined, 'Using default value: "abc"');
-        createParamLensTest('requiredString', undefined, 'No value found');
+        createParamLensTest('requiredString', undefined, '$(warning) No value found');
 
         // Value too long
         createParamLensTest(

--- a/test/NestedTemplates.test.ts
+++ b/test/NestedTemplates.test.ts
@@ -256,7 +256,9 @@ suite("Nested templates", () => {
             const {
                 dt,
                 markers: { p1rootdef, p1rootref1, p1rootref2, p1rootref3, p1innerdef, p1innerref1, p1innerref2, p1innerref3 }
-            } = await parseTemplateWithMarkers(template, []);
+            } = await parseTemplateWithMarkers(template, [
+                "Warning: The variable 'v1' is never used."
+            ]);
 
             // root p1
             const p1rootref1pc = dt.getContextFromDocumentCharacterIndex(p1rootref1.index, undefined);
@@ -443,7 +445,12 @@ suite("Nested templates", () => {
             const {
                 dt,
                 markers: { v1def, v1ref1, v1ref2, v1ref3, v1ref4, v2def, v2ref1 }
-            } = await parseTemplateWithMarkers(template, []);
+            } = await parseTemplateWithMarkers(
+                template,
+                [
+                    "Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'."
+                ]
+            );
 
             // v1
             const v1ref1pc = dt.getContextFromDocumentCharacterIndex(v1ref1.index, undefined);
@@ -513,7 +520,15 @@ suite("Nested templates", () => {
             const {
                 dt,
                 markers: { p1def, p1ref1, p1ref2, p1ref3, p1ref4, p1ref5 }
-            } = await parseTemplateWithMarkers(template, []);
+            } = await parseTemplateWithMarkers(
+                template,
+                [
+                    "19: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                    "22: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'."
+                ],
+                {
+                    includeDiagnosticLineNumbers: true
+                });
 
             // p1
             const p1ref1pc = dt.getContextFromDocumentCharacterIndex(p1ref1.index, undefined);
@@ -642,6 +657,52 @@ suite("Nested templates", () => {
                 fromFile: true,
                 includeDiagnosticLineNumbers: true
             });
+    });
+    test("No duplicate warnings from outer scoped nested template using same scope as parent", async () => {
+        await parseTemplate(
+            {
+                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                    "p2": { // WARNING: unused
+                        "type": "string",
+                        "defaultValue": "abc"
+                    },
+                },
+                "variables": {
+                    "v1": "warning: unused"
+                },
+                "functions": [
+                    {
+                        "namespace": "udf",
+                        "members": {
+                            "notUsed": {
+                            }
+                        }
+                    }
+                ],
+                "resources": [
+                    {
+                        "type": "Microsoft.Resources/deployments",
+                        "apiVersion": "2015-01-01",
+                        "name": "outer1",
+                        "properties": {
+                            "mode": "Incremental",
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                "contentVersion": "1.2.3.4",
+                                "resources": []
+                            }
+                        }
+                    }
+                ]
+            },
+            [
+                "Warning: The parameter 'p2' is never used.",
+                "Warning: The variable 'v1' is never used.",
+                "Warning: The user-defined function 'udf.notUsed' is never used."
+            ]
+        );
     });
 
     suite("deeply nested", () => {

--- a/test/NestedTemplates.test.ts
+++ b/test/NestedTemplates.test.ts
@@ -633,9 +633,9 @@ suite("Nested templates", () => {
                 "71: Warning: User-function parameter 'p1' is never used.",
                 "80: Warning: The user-defined function 'udf.func2' is never used.",
                 "97: Warning: The user-defined function 'udf2.func3' is never used.",
-                "121: Error: Inaccessible varaibles",
-                "125: Error: Inaccessible parameters",
-                "130: Error: Inaccessible functoins",
+                "121: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                "125: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                "130: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
                 "147: Error: Undefined parameter reference: 'p3'"
             ],
             {

--- a/test/NestedTemplates.test.ts
+++ b/test/NestedTemplates.test.ts
@@ -448,7 +448,7 @@ suite("Nested templates", () => {
             } = await parseTemplateWithMarkers(
                 template,
                 [
-                    "Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'."
+                    "Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'."
                 ]
             );
 
@@ -523,8 +523,8 @@ suite("Nested templates", () => {
             } = await parseTemplateWithMarkers(
                 template,
                 [
-                    "19: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
-                    "22: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'."
+                    "19: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                    "22: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'."
                 ],
                 {
                     includeDiagnosticLineNumbers: true
@@ -648,9 +648,9 @@ suite("Nested templates", () => {
                 "71: Warning: User-function parameter 'p1' is never used.",
                 "80: Warning: The user-defined function 'udf.func2' is never used.",
                 "97: Warning: The user-defined function 'udf2.func3' is never used.",
-                "121: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
-                "125: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
-                "130: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you want inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                "121: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                "125: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
+                "130: Warning: Variables, parameters and user functions of an outer-scoped nested template are inaccessible to any expressions. If you intended inner scope, set properties.nestedDeploymentExprEvalOptions.scope to 'inner'.",
                 "147: Error: Undefined parameter reference: 'p3'"
             ],
             {

--- a/test/NestedTemplates.test.ts
+++ b/test/NestedTemplates.test.ts
@@ -620,6 +620,30 @@ suite("Nested templates", () => {
         });
     });
 
+    test("errors/warnings", async () => {
+        await parseTemplate(
+            'templates/nestedTemplateScopesErrorsAndWarnings.json',
+            [
+                "8: Warning: The parameter 'p2' is never used.",
+                "12: Warning: The parameter 'p4' is never used.",
+                "17: Warning: The variable 'v1' is never used.",
+                "35: Warning: The variable 'v2' is never used.",
+                "53: Error: Undefined parameter reference: 'p4'",
+                "60: Warning: The parameter 'p2' is never used.",
+                "71: Warning: User-function parameter 'p1' is never used.",
+                "80: Warning: The user-defined function 'udf.func2' is never used.",
+                "97: Warning: The user-defined function 'udf2.func3' is never used.",
+                "121: Error: Inaccessible varaibles",
+                "125: Error: Inaccessible parameters",
+                "130: Error: Inaccessible functoins",
+                "147: Error: Undefined parameter reference: 'p3'"
+            ],
+            {
+                fromFile: true,
+                includeDiagnosticLineNumbers: true
+            });
+    });
+
     suite("deeply nested", () => {
         const deeplyNestedTemplate = {
             "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",

--- a/test/UserFunctions.test.ts
+++ b/test/UserFunctions.test.ts
@@ -1485,7 +1485,7 @@ suite("User functions", () => {
                 };
 
                 await parseTemplate(template, [
-                    "Warning: The parameter 'param1' of function 'udf.odd' is never used.",
+                    "Warning: User-function parameter 'param1' is never used.",
                     "Warning: The user-defined function 'udf.odd' is never used."
                 ]);
             });
@@ -1526,7 +1526,7 @@ suite("User functions", () => {
                 };
 
                 await parseTemplate(template, [
-                    "Warning: The parameter 'param1' of function 'udf.odd' is never used.",
+                    "Warning: User-function parameter 'param1' is never used.",
                     "Warning: The user-defined function 'udf.odd' is never used."
                 ]);
             });
@@ -1562,7 +1562,7 @@ suite("User functions", () => {
 
                 await parseTemplate(template, [
                     "Warning: The parameter 'param1' is never used.",
-                    "Warning: The parameter 'param1' of function 'udf.odd' is never used.",
+                    "Warning: User-function parameter 'param1' is never used.",
                     'Warning: The user-defined function \'udf.odd\' is never used.'
                 ]);
             });

--- a/test/formatDocument.test.ts
+++ b/test/formatDocument.test.ts
@@ -14,9 +14,10 @@ import { ISuiteCallbackContext, ITestCallbackContext } from "mocha";
 import * as path from 'path';
 import { commands, languages, Range, Selection, TextDocument, TextEditor, window, workspace } from "vscode";
 import { armTemplateLanguageId } from "../extension.bundle";
-import { diagnosticsTimeout, testFolder } from "./support/diagnostics";
+import { diagnosticsTimeout } from "./support/diagnostics";
 import { ensureLanguageServerAvailable } from "./support/ensureLanguageServerAvailable";
 import { getTempFilePath } from "./support/getTempFilePath";
+import { resolveInTestFolder } from "./support/resolveInTestFolder";
 import { testWithLanguageServer } from "./support/testWithLanguageServer";
 
 const formatDocumentCommand = 'editor.action.formatDocument';
@@ -31,11 +32,11 @@ suite("Format document", function (this: ISuiteCallbackContext): void {
             let jsonUnformatted: string = source;
             if (source.match(/\.jsonc?$/)) {
                 sourceIsFile = true;
-                jsonUnformatted = fs.readFileSync(path.join(testFolder, source)).toString().trim();
+                jsonUnformatted = fs.readFileSync(resolveInTestFolder(source)).toString().trim();
             }
             let jsonExpected: string = expected;
             if (jsonExpected.match(/\.jsonc?$/)) {
-                jsonExpected = fs.readFileSync(path.join(testFolder, expected)).toString().trim();
+                jsonExpected = fs.readFileSync(resolveInTestFolder(expected)).toString().trim();
             }
 
             if (source === 'format-me.json') {

--- a/test/functional/snippets.test.ts
+++ b/test/functional/snippets.test.ts
@@ -134,11 +134,11 @@ const overrideExpectedDiagnostics: { [name: string]: string[] } = {
     ],
     "User Function": [
         "The user-defined function 'udf.functionname' is never used.",
-        "The parameter 'parametername' of function 'udf.functionname' is never used."
+        "User-function parameter 'parametername' is never used."
     ],
     "User Function Namespace": [
         "The user-defined function 'namespacename.functionname' is never used.",
-        "The parameter 'parametername' of function 'namespacename.functionname' is never used."
+        "User-function parameter 'parametername' is never used."
     ],
     "Automation Certificate": [
         // TODO: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1012620

--- a/test/functional/snippets.test.ts
+++ b/test/functional/snippets.test.ts
@@ -16,8 +16,9 @@ import * as path from 'path';
 import { commands, Diagnostic, Selection, Uri, window, workspace } from "vscode";
 import { DeploymentTemplate, ext, getVSCodePositionFromPosition } from '../../extension.bundle';
 import { delay } from '../support/delay';
-import { diagnosticSources, getDiagnosticsForDocument, testFolder } from '../support/diagnostics';
+import { diagnosticSources, getDiagnosticsForDocument } from '../support/diagnostics';
 import { getTempFilePath } from "../support/getTempFilePath";
+import { resolveInTestFolder } from '../support/resolveInTestFolder';
 import { testWithLanguageServer } from '../support/testWithLanguageServer';
 
 const EOL = ext.EOL;
@@ -379,7 +380,7 @@ suite("Snippets functional tests", () => {
 
     function createSnippetTests(snippetsFile: string): void {
         suite(snippetsFile, () => {
-            const snippetsPath = path.join(testFolder, '..', 'assets', snippetsFile);
+            const snippetsPath = resolveInTestFolder(path.join('..', 'assets', snippetsFile));
             const snippets = <{ [name: string]: ISnippet }>fse.readJsonSync(snippetsPath);
             // tslint:disable-next-line:no-for-in forin
             for (let snippetName in snippets) {

--- a/test/support/diagnostics.ts
+++ b/test/support/diagnostics.ts
@@ -20,11 +20,11 @@ import { Diagnostic, DiagnosticSeverity, Disposable, languages, TextDocument } f
 import { diagnosticsCompletePrefix, expressionsDiagnosticsSource, ExpressionType, ext, LanguageServerState, languageServerStateSource } from "../../extension.bundle";
 import { DISABLE_LANGUAGE_SERVER } from "../testConstants";
 import { parseParametersWithMarkers } from "./parseTemplate";
+import { resolveInTestFolder } from "./resolveInTestFolder";
 import { stringify } from "./stringify";
 import { TempDocument, TempEditor, TempFile } from "./TempFile";
 
 export const diagnosticsTimeout = 2 * 60 * 1000; // CONSIDER: Use this long timeout only for first test, or for suite setup
-export const testFolder = path.join(__dirname, '..', '..', '..', 'test');
 
 export interface DiagnosticSource {
     name: string;
@@ -361,7 +361,7 @@ export async function getDiagnosticsForTemplate(
         if (typeof templateContentsOrFileName === 'string') {
             if (!!templateContentsOrFileName.match(/\.jsonc?$/)) {
                 // It's a filename
-                let sourcePath = path.join(testFolder, templateContentsOrFileName);
+                let sourcePath = resolveInTestFolder(templateContentsOrFileName);
                 templateContents = fs.readFileSync(sourcePath).toString();
                 tempPathSuffix = path.basename(templateContentsOrFileName, path.extname(templateContentsOrFileName));
             } else {
@@ -393,7 +393,7 @@ export async function getDiagnosticsForTemplate(
                 const { unmarkedText: unmarkedParams } = await parseParametersWithMarkers(options.parameters);
                 paramsFile = new TempFile(unmarkedParams);
             } else {
-                const absPath = path.join(testFolder, options.parametersFile!);
+                const absPath = resolveInTestFolder(options.parametersFile!);
                 paramsFile = await TempFile.fromExistingFile(absPath);
             }
 

--- a/test/support/parseTemplate.ts
+++ b/test/support/parseTemplate.ts
@@ -90,11 +90,14 @@ export async function parseTemplateWithMarkers(
         if (!options || !options.ignoreWarnings) {
             expected = expected.concat(warningMessages);
         }
-        const expectedMessages = expected.sort((d1, d2) => {
-            return d1.line - d2.line;
-        }).map(d => d.msg);
+        const sortedExpectedDiag =
+            expected.sort(
+                options?.includeDiagnosticLineNumbers
+                    ? (d1, d2): number => d1.line - d2.line
+                    : undefined);
+        const expectedMessages = sortedExpectedDiag.map(d => d.msg);
 
-        assert.deepStrictEqual(expectedMessages, expectedDiagnosticMessages);
+        assert.deepEqual(expectedMessages, expectedDiagnosticMessages);
     }
 
     return { dt, markers };

--- a/test/support/parseTemplate.ts
+++ b/test/support/parseTemplate.ts
@@ -3,10 +3,12 @@
 // ----------------------------------------------------------------------------
 
 import * as assert from 'assert';
+import * as fse from 'fs-extra';
 import { Uri } from 'vscode';
 import { parseError } from 'vscode-azureextensionui';
 import { DeploymentParameters, DeploymentTemplate, Issue } from "../../extension.bundle";
 import { IDeploymentParametersFile, IPartialDeploymentTemplate } from './diagnostics';
+import { resolveInTestFolder } from './resolveInTestFolder';
 import { stringify } from "./stringify";
 
 /**
@@ -16,7 +18,9 @@ export async function parseTemplate(
     template: string | IPartialDeploymentTemplate,
     expectedDiagnosticMessages?: string[],
     options?: {
+        fromFile?: boolean; // if true, template is a path
         ignoreWarnings?: boolean;
+        includeDiagnosticLineNumbers?: boolean;
         replacements?: { [key: string]: string | { [key: string]: unknown } };
     }
 ): Promise<DeploymentTemplate> {
@@ -42,26 +46,54 @@ export async function parseTemplateWithMarkers(
     template: string | IPartialDeploymentTemplate,
     expectedDiagnosticMessages?: string[],
     options?: {
+        fromFile?: boolean; // if true, template is a path
         ignoreWarnings?: boolean;
+        includeDiagnosticLineNumbers?: boolean;
         ignoreBang?: boolean;
         replacements?: { [key: string]: string | { [key: string]: unknown } };
     }
 ): Promise<{ dt: DeploymentTemplate; markers: Markers }> {
+    if (options?.fromFile) {
+        const absPath = resolveInTestFolder(<string>template);
+        const contents: string = fse.readFileSync(absPath).toString();
+        template = contents;
+    }
+
     const withReplacements = options?.replacements ? replaceInTemplate(template, options.replacements) : template;
     const { unmarkedText, markers } = getDocumentMarkers(withReplacements, options);
     const dt: DeploymentTemplate = new DeploymentTemplate(unmarkedText, Uri.file("https://parseTemplate template"));
 
+    type DiagIssue = {
+        line: number;
+        msg: string;
+        kind: 'Error' | 'Warning';
+    };
+
     // Always run these even if not checking against expected, to verify nothing throws
     const errors: Issue[] = await dt.getErrors(undefined);
     const warnings: Issue[] = dt.getWarnings();
-    const errorMessages = errors.map(e => `Error: ${e.message}`);
-    const warningMessages = warnings.map(e => `Warning: ${e.message}`);
+    const errorMessages = errors.map(e => <DiagIssue>{ line: e.span.startIndex, msg: getMessage(e, true), kind: 'Error' });
+    const warningMessages = warnings.map(e => <DiagIssue>{ line: e.span.startIndex, msg: getMessage(e, false), kind: 'Warning' });
+
+    function getMessage(d: Issue, isError: boolean): string {
+        const typeString = isError ? 'Error' : 'Warning';
+        let msg = `${typeString}: ${d.message}`;
+        if (options?.includeDiagnosticLineNumbers) {
+            msg = `${dt.getDocumentPosition(d.span.startIndex).line + 1}: ${msg}`;
+        }
+
+        return msg;
+    }
 
     if (expectedDiagnosticMessages) {
-        let expectedMessages = errorMessages;
+        let expected = errorMessages;
         if (!options || !options.ignoreWarnings) {
-            expectedMessages = expectedMessages.concat(warningMessages);
+            expected = expected.concat(warningMessages);
         }
+        const expectedMessages = expected.sort((d1, d2) => {
+            return d1.line - d2.line;
+        }).map(d => d.msg);
+
         assert.deepStrictEqual(expectedMessages, expectedDiagnosticMessages);
     }
 

--- a/test/support/resolveInTestFolder.ts
+++ b/test/support/resolveInTestFolder.ts
@@ -1,0 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------------------
+
+import * as path from 'path';
+
+export const testFolder = path.join(__dirname, '..', '..', '..', 'test');
+
+export function resolveInTestFolder(relativePath: string): string {
+    return path.join(testFolder, relativePath);
+}

--- a/test/templates/nestedTemplateScopesErrorsAndWarnings.json
+++ b/test/templates/nestedTemplateScopesErrorsAndWarnings.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "p1": {
+            "type": "string"
+        },
+        "p2": { // WARNING: unused
+            "type": "string",
+            "defaultValue": "abc"
+        },
+        "p4": { // WARNING: unused
+            "type": "string"
+        }
+    },
+    "variables": {
+        "v1": "v1 from parent", // WARNING: unused
+        "v2": "v2 from parent"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "name": "inner1",
+            "apiVersion": "2019-07-01",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "mode": "Complete",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "variables": {
+                        "v1": "v1 from inner1",
+                        "v2": "v2 from inner1" // WARNING: unused
+                    },
+                    "resources": [],
+                    "outputs": {
+                        "out1": {
+                            "type": "string",
+                            "value": "[variables('v1')]"
+                        },
+                        "out2": {
+                            "type": "string",
+                            "value": "[parameters('p1')]"
+                        },
+                        "out3": {
+                            "type": "string",
+                            "value": "[udf.func1(123)]"
+                        },
+                        "out4": {
+                            "type": "string",
+                            "value": "[parameters('p4')]" // ERROR: undefined
+                        }
+                    },
+                    "parameters": {
+                        "p1": {
+                            "type": "string"
+                        },
+                        "p2": { // WARNING: unused
+                            "type": "int"
+                        }
+                    },
+                    "functions": [
+                        {
+                            "namespace": "udf",
+                            "members": {
+                                "func1": {
+                                    "parameters": [
+                                        {
+                                            "name": "p1", // WARNING: unused
+                                            "type": "int"
+                                        }
+                                    ],
+                                    "output": {
+                                        "type": "int",
+                                        "value": 123
+                                    }
+                                },
+                                "func2": { // WARNING: unused
+                                    "parameters": [
+                                        {
+                                            "name": "p1",
+                                            "type": "int"
+                                        }
+                                    ],
+                                    "output": {
+                                        "type": "string",
+                                        "value": "[add(parameters('p1'), 1)]"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "namespace": "udf2",
+                            "members": {
+                                "func3": { // WARNING: unused
+                                    "output": {
+                                        "type": "array",
+                                        "value": []
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2015-01-01",
+            "name": "outer1",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "outer"
+                },
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.2.3.4",
+                    "variables": { // WARNING: inaccessible
+                        "v1": "v1 from outer1",
+                        "v2": "not used"
+                    },
+                    "parameters": { // WARNING: inaccessible
+                        "p1": {
+                            "type": "securestring"
+                        }
+                    },
+                    "functions": [ // WARNING: inaccessible
+                        {
+                            "namespace": "ns1"
+                        }
+                    ],
+                    "resources": [],
+                    "outputs": {
+                        "v1": {
+                            "type": "string",
+                            "value": "[variables('v2')]"
+                        },
+                        "out1": {
+                            "type": "string",
+                            "value": "[parameters('p1')]"
+                        },
+                        "out2": {
+                            "type": "string",
+                            "value": "[parameters('p3')]" // ERROR: undefined
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fixes part of #484 

Two things:
1) We weren't looking for warnings in deeper scopes
2) Added new warning about inaccessible members for outer-scoped nested templates.