### PR TITLE
Added test override for resource group snippet

### DIFF
--- a/test/functional/snippets.test.ts
+++ b/test/functional/snippets.test.ts
@@ -86,7 +86,16 @@ const overrideTemplateForSnippet: { [name: string]: string } = {
 \t"functions": [
 \t\t//Insert here: namespace
 \t]
+}`,
+
+    "Resource Group": `{
+\t"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+\t"contentVersion": "1.0.0.0",
+\t"resources": [
+\t\t//Insert here: resource
+\t]
 }`
+
 };
 
 // Override where to insert the snippet during the test - default is to insert with the "Resources" section, at "Insert here: resource"


### PR DESCRIPTION
Added suite override for resource group snippet tests (subscription scoped deployment). This override is needed to support this pull request.

https://github.com/microsoft/vscode-azurearmtools/pull/726