### PR TITLE
Fix keyvault values in code lens

### DIFF
--- a/src/deploymentTemplateCodeLenses.ts
+++ b/src/deploymentTemplateCodeLenses.ts
@@ -5,7 +5,7 @@
 // tslint:disable: max-classes-per-file
 
 import * as assert from 'assert';
-import { Json, Language } from '../extension.bundle';
+import { Language } from '../extension.bundle';
 import { DeploymentDocument, ResolvableCodeLens } from "./DeploymentDocument";
 import { DeploymentTemplate } from './DeploymentTemplate';
 import { IParameterDefinition } from './IParameterDefinition';
@@ -78,18 +78,17 @@ export class ParameterDefinitionCodeLens extends ResolvableCodeLens {
             assert(associatedDocument instanceof DeploymentParameters);
             const dp = associatedDocument as DeploymentParameters;
 
-            const paramValue = dp.getParameterValue(this.parameterDefinition.nameValue.unquotedValue)
-                ?.value;
+            const param = dp.getParameterValue(this.parameterDefinition.nameValue.unquotedValue);
+            const paramValue = param?.value;
+            const paramReference = param?.reference;
             const givenValueAsString = paramValue?.toFullFriendlyString();
             const defaultValueAsString = this.parameterDefinition.defaultValue?.toFullFriendlyString();
 
             let title;
-            if (givenValueAsString !== undefined) {
-                if (this.isKeyVaultReference(paramValue)) {
-                    title = 'Value: (KeyVault reference)';
-                } else {
-                    title = `Value: ${givenValueAsString}`;
-                }
+            if (!!paramReference) {
+                title = 'Value: (KeyVault reference)';
+            } else if (givenValueAsString !== undefined) {
+                title = `Value: ${givenValueAsString}`;
             } else if (defaultValueAsString !== undefined) {
                 title = `Using default value: ${defaultValueAsString}`;
             } else {
@@ -113,29 +112,6 @@ export class ParameterDefinitionCodeLens extends ResolvableCodeLens {
         }
 
         return false;
-    }
-
-    private isKeyVaultReference(paramValue: Json.Value | undefined): boolean {
-        /* keyVault references inside a parameter file look like this:
-            {
-                "reference": {
-                    "keyVault": {
-                        "id": "/subscriptions/xxxxx/resourceGroups/yyyyy/providers/Microsoft.KeyVault/vaults/zzzzz"
-                    },
-                    "secretName": "mysecretpassword"
-                }
-            }
-        */
-        const keyVaultReferenceProperty: string = 'reference';
-        const keyVaultReferenceKeyVaultProperty: string = 'keyvault';
-        const keyVaultReferenceKeyVaultIdProperty: string = 'id';
-
-        return !!paramValue?.asObjectValue
-            ?.getPropertyValue(keyVaultReferenceProperty)
-            ?.asObjectValue
-            ?.getPropertyValue(keyVaultReferenceKeyVaultProperty)
-            ?.asObjectValue
-            ?.getPropertyValue(keyVaultReferenceKeyVaultIdProperty);
     }
 }
 

--- a/src/parameterFiles/ParameterValueDefinition.ts
+++ b/src/parameterFiles/ParameterValueDefinition.ts
@@ -39,6 +39,15 @@ export class ParameterValueDefinition implements INamedDefinition {
         return undefined;
     }
 
+    public get reference(): Json.Value | undefined {
+        const parameterValue: Json.ObjectValue | undefined = Json.asObjectValue(this._property.value);
+        if (parameterValue) {
+            return parameterValue.getPropertyValue("reference");
+        }
+
+        return undefined;
+    }
+
     public get usageInfo(): IUsageInfo {
         return {
             usage: this.nameValue.unquotedValue,

--- a/test/DeploymentTemplate.CodeLenses.test.ts
+++ b/test/DeploymentTemplate.CodeLenses.test.ts
@@ -155,10 +155,10 @@ suite("DeploymentTemplate code lenses", () => {
     });
 
     suite("parameter definition code lenses with a parameter file", () => {
-        function createParamLensTest(topLevelParamName: string, valueInParamFile: string | undefined, expectedTitle: string): void {
+        function createParamLensTest(topLevelParamName: string, valueInParamFile: { value?: string; reference?: string } | undefined, expectedTitle: string): void {
             const testName = valueInParamFile === undefined ?
                 `${topLevelParamName} with no value in param file` :
-                `${topLevelParamName} with value ${valueInParamFile.replace(/\r\n|\n/g, ' ')}`;
+                `${topLevelParamName} with value ${JSON.stringify(valueInParamFile).replace(/\r\n|\n/g, ' ')}`;
             test(testName, async () => {
                 const dt = await parseTemplate(template);
                 const param = dt.topLevelScope.getParameterDefinition(topLevelParamName);
@@ -166,13 +166,19 @@ suite("DeploymentTemplate code lenses", () => {
                 const { dp } = await parseParametersWithMarkers(
                     valueInParamFile === undefined ? {
                         "parameters": {}
-                    } : `{
+                    } : valueInParamFile.value ? `{
                         "parameters": {
                             "${topLevelParamName}": {
-                                "value": ${valueInParamFile}
+                                "value": ${valueInParamFile.value}
                             }
                         }
-                    }`);
+                    }` : `{
+                            "parameters": {
+                                "${topLevelParamName}": {
+                                    "reference": ${valueInParamFile.reference}
+                                }
+                            }
+                        }`);
                 const lenses = dt.getCodeLenses(true)
                     .filter(l => l instanceof ParameterDefinitionCodeLens)
                     .map(l => <ParameterDefinitionCodeLens>l);
@@ -192,58 +198,57 @@ suite("DeploymentTemplate code lenses", () => {
             });
         }
 
-        createParamLensTest('requiredInt', '123', 'Value: 123');
-        createParamLensTest('requiredInt', '-123', 'Value: -123');
+        createParamLensTest('requiredInt', { value: '123' }, 'Value: 123');
+        createParamLensTest('requiredInt', { value: '-123' }, 'Value: -123');
         createParamLensTest('optionalInt', undefined, 'Using default value: 123');
         createParamLensTest('requiredInt', undefined, 'No value found');
 
-        createParamLensTest('requiredString', '"def"', 'Value: "def"');
+        createParamLensTest('requiredString', { value: '"def"' }, 'Value: "def"');
         createParamLensTest('optionalString', undefined, 'Using default value: "abc"');
         createParamLensTest('requiredString', undefined, 'No value found');
 
         // Value too long
         createParamLensTest(
             'requiredString',
-            '"I am a very long string, yes, sir, a very long string indeed.  If I were a very long string, I would say that I am a very long string, yes, sir, a very long string indeed."',
+            { value: '"I am a very long string, yes, sir, a very long string indeed.  If I were a very long string, I would say that I am a very long string, yes, sir, a very long string indeed."' },
             'Value: "I am a very long string, yes, sir, a very long string indeed.  If I were a very long string, I would say that I ...');
 
-        createParamLensTest('optionalSecureString', '"def"', 'Value: "def"');
+        createParamLensTest('optionalSecureString', { value: '"def"' }, 'Value: "def"');
         createParamLensTest('optionalSecureString', undefined, 'Using default value: "abc"');
         createParamLensTest(
             'optionalSecureString',
-            `{
-                "reference": {
+            {
+                reference: `{
                     "keyVault": {
                         "id": "/subscriptions/*************/resourceGroups/*******/providers/Microsoft.KeyVault/vaults/****"
                     },
                     "secretName": "mysecretpassword"
-                }
-            }`,
+            }`},
             'Value: (KeyVault reference)');
 
-        createParamLensTest('optionalBool', 'true', 'Value: true');
-        createParamLensTest('optionalBool', 'false', 'Value: false');
+        createParamLensTest('optionalBool', { value: 'true' }, 'Value: true');
+        createParamLensTest('optionalBool', { value: 'false' }, 'Value: false');
         createParamLensTest('optionalBool', undefined, 'Using default value: true');
 
-        createParamLensTest('optionalArray', '[]', 'Value: []');
-        createParamLensTest('optionalArray', '[\n]', 'Value: []');
-        createParamLensTest('optionalArray', '[\r\n]', 'Value: []');
-        createParamLensTest('optionalArray', '[\r\n\t     123\t\r\n    ]', 'Value: [123]');
-        createParamLensTest('optionalArray', '[\r\n\t     {"a": "b"}\t\r\n    ]', 'Value: [{"a": "b"}]');
+        createParamLensTest('optionalArray', { value: '[]' }, 'Value: []');
+        createParamLensTest('optionalArray', { value: '[\n]' }, 'Value: []');
+        createParamLensTest('optionalArray', { value: '[\r\n]' }, 'Value: []');
+        createParamLensTest('optionalArray', { value: '[\r\n\t     123\t\r\n    ]' }, 'Value: [123]');
+        createParamLensTest('optionalArray', { value: '[\r\n\t     {"a": "b"}\t\r\n    ]' }, 'Value: [{"a": "b"}]');
         createParamLensTest('optionalArray', undefined, 'Using default value: [true]');
 
-        createParamLensTest('optionalObject', '{}', 'Value: {}');
-        createParamLensTest('optionalObject', '{\r\n"a": "b",\r\n  "i": -123}', 'Value: {"a": "b", "i": -123}');
+        createParamLensTest('optionalObject', { value: '{}' }, 'Value: {}');
+        createParamLensTest('optionalObject', { value: '{\r\n"a": "b",\r\n  "i": -123}' }, 'Value: {"a": "b", "i": -123}');
         createParamLensTest('optionalObject', undefined, 'Using default value: {"myTrueProp": true}');
 
-        createParamLensTest('optionalSecureObject', '{}', 'Value: {}');
+        createParamLensTest('optionalSecureObject', { value: '{}' }, 'Value: {}');
         createParamLensTest('optionalSecureObject', undefined, 'Using default value: {"value1": true}');
 
         suite("undefined in param value", () => {
-            createParamLensTest('optionalString', 'undefined', 'Using default value: "abc"');
+            createParamLensTest('optionalString', { value: 'undefined' }, 'Using default value: "abc"');
         });
         suite("Expression in default value", () => {
-            createParamLensTest('optionalString2', '"123"', 'Value: "123"');
+            createParamLensTest('optionalString2', { value: '"123"' }, 'Value: "123"');
             createParamLensTest('optionalString2', undefined, `Using default value: "[parameters('optionalString')]"`);
         });
     });


### PR DESCRIPTION
Should have been looking for this format for keyvault references in parameter files:
```
{
  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
  "contentVersion": "1.0.0.0",
  "parameters": {
      "adminLogin": {
        "value": "exampleadmin"
      },
      "adminPassword": {
        "reference": {  <<<<<<<<<<<<<<<<<<<<
          "keyVault": {
          "id": "/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.KeyVault/vaults/<vault-name>"
          },
          "secretName": "ExamplePassword"
        }
      },
      "sqlServerName": {
        "value": "<your-server-name>"
      }
  }
}
```

But instead it was looking for this:
```
{
  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
  "contentVersion": "1.0.0.0",
  "parameters": {
      "adminPassword": {
        "value": {     <<<<<<<<<<<<<<<<<<<<
          "reference": {
            "keyVault": {
            "id": "/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.KeyVault/vaults/<vault-name>"
            },
            "secretName": "ExamplePassword"
          }
        }
      },
      "sqlServerName": {
        "value": "<your-server-name>"
      }
  }
}
```