### PR TITLE
Quick safe fix for 810

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -1063,9 +1063,17 @@ export class AzureRMTools {
 
             if (codeLens instanceof ResolvableCodeLens) {
                 const cancel = new Cancellation(token);
-                const { associatedDoc } = await this.getDeploymentDocAndAssociatedDoc(codeLens.deploymentDoc.documentUri, cancel);
-                if (codeLens.resolve(associatedDoc)) {
-                    assert(codeLens.command?.command && codeLens.command.title, "CodeLens wasn't resolved");
+                try {
+                    const { associatedDoc } = await this.getDeploymentDocAndAssociatedDoc(codeLens.deploymentDoc.documentUri, cancel);
+                    if (codeLens.resolve(associatedDoc)) {
+                        assert(codeLens.command?.command && codeLens.command.title, "CodeLens wasn't resolved");
+                        return codeLens;
+                    }
+                } catch (err) {
+                    codeLens.command = {
+                        title: 'Unable to open parameter file',
+                        command: ''
+                    };
                     return codeLens;
                 }
             } else {


### PR DESCRIPTION
Partial fix for #810

Will create a better fix for next release.  This gets rid of the error popup and the !!ERROR!! alerts in the code lenses.  Ideally you'd still be able to use code lenses to fix the broken parameter file association.

![image](https://user-images.githubusercontent.com/6913354/85349816-48665380-b4b4-11ea-8af0-0fd188805099.png)
