### PR TITLE
Fix telemetry for existing-parameter-value and make IDs easier

### DIFF
--- a/src/Completion.ts
+++ b/src/Completion.ts
@@ -186,12 +186,12 @@ export enum CompletionKind {
     UserFunction = "UserFunction",
 
     // Template file completions
-    DtResourceIdResType = "DtResourceIdResType", // First arg of resourceId
-    DtResourceIdResName = "DtResourceIdResName", // Second arg of resourceId
+    ResourceIdResTypeParameter = "ResourceIdResTypeParameter", // First arg of resourceId
+    ResourceIdResNameParameter = "ResourceIdResNameParameter", // Second arg of resourceId
 
     // Parameter file completions
-    DpPropertyValue = "DpPropertyValue", // Parameter from the template file
-    DpNewPropertyValue = "DpNewPropertyValue", // New, unnamed parameter
+    PropertyValueForExistingProperty = "PropertyValueForExistingProperty", // Parameter from the template file
+    PropertyValueForNewProperty = "PropertyValueForNewProperty", // New, unnamed parameter
 
     // Snippet
     Snippet = "Snippet",

--- a/src/getResourceIdCompletions.ts
+++ b/src/getResourceIdCompletions.ts
@@ -122,7 +122,7 @@ function getCompletions(
                 label,
                 insertText,
                 span,
-                kind: Completion.CompletionKind.DtResourceIdResName,
+                kind: Completion.CompletionKind.ResourceIdResNameParameter,
                 priority: Completion.CompletionPriority.high,
                 // Force the first of the resourceId completions to be preselected, otherwise
                 // vscode tends to preselect one of the regular function completions based
@@ -224,7 +224,7 @@ function getResourceTypeCompletions(
             label,
             insertText,
             span,
-            kind: Completion.CompletionKind.DtResourceIdResType,
+            kind: Completion.CompletionKind.ResourceIdResTypeParameter,
             priority: Completion.CompletionPriority.high,
             // Force the first of the resourceId completions to be preselected, otherwise
             // vscode tends to preselect one of the regular function completions based

--- a/src/parameterFiles/ParametersPositionContext.ts
+++ b/src/parameterFiles/ParametersPositionContext.ts
@@ -109,7 +109,7 @@ export class ParametersPositionContext extends PositionContext {
         return this.createParameterCompletion(
             label,
             snippet,
-            Completion.CompletionKind.DpNewPropertyValue,
+            Completion.CompletionKind.PropertyValueForNewProperty,
             detail,
             documentation);
     }
@@ -145,7 +145,7 @@ export class ParametersPositionContext extends PositionContext {
                     this.createParameterCompletion(
                         label,
                         replacement,
-                        Completion.CompletionKind.DtResourceIdResType,
+                        Completion.CompletionKind.PropertyValueForExistingProperty,
                         detail,
                         documentation));
             }

--- a/src/util/toVsCodeCompletionItem.ts
+++ b/src/util/toVsCodeCompletionItem.ts
@@ -59,16 +59,16 @@ export function toVsCodeCompletionItem(deploymentFile: DeploymentDocument, item:
             vscodeItem.kind = vscode.CompletionItemKind.Unit;
             break;
 
-        case Completion.CompletionKind.DpPropertyValue:
+        case Completion.CompletionKind.PropertyValueForExistingProperty:
             vscodeItem.kind = vscode.CompletionItemKind.Property;
             break;
 
-        case Completion.CompletionKind.DpNewPropertyValue:
+        case Completion.CompletionKind.PropertyValueForNewProperty:
             vscodeItem.kind = vscode.CompletionItemKind.Snippet;
             break;
 
-        case Completion.CompletionKind.DtResourceIdResType:
-        case Completion.CompletionKind.DtResourceIdResName:
+        case Completion.CompletionKind.ResourceIdResTypeParameter:
+        case Completion.CompletionKind.ResourceIdResNameParameter:
             vscodeItem.kind = vscode.CompletionItemKind.Reference;
             break;
 


### PR DESCRIPTION
This one is a fix:

                     this.createParameterCompletion(
                         label,
                         replacement,
-                        Completion.CompletionKind.DtResourceIdResType,
+                        Completion.CompletionKind.PropertyValueForExistingProperty,
                         detail,
                         documentation));
             }

The others are simple renames.