### PR TITLE
Fix 838, file does not appear to be ARM template

### DIFF
--- a/src/parameterFiles/parameterFiles.ts
+++ b/src/parameterFiles/parameterFiles.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { commands, MessageItem, TextDocument, Uri, window, workspace } from 'vscode';
 import { callWithTelemetryAndErrorHandling, DialogResponses, IActionContext, IAzureQuickPickItem, UserCancelledError } from 'vscode-azureextensionui';
-import { configKeys, configPrefix, globalStateKeys } from '../constants';
+import { armTemplateLanguageId, configKeys, configPrefix, globalStateKeys } from '../constants';
 import { DeploymentTemplate } from '../DeploymentTemplate';
 import { ext } from '../extensionVariables';
 import { queryCreateParameterFile } from '../parameterFileGeneration';
@@ -15,7 +15,6 @@ import { containsParametersSchema } from '../schemas';
 import { documentSchemes } from '../supported';
 import { normalizePath } from '../util/normalizePath';
 import { pathExists } from '../util/pathExists';
-import { readUtf8FileWithBom } from '../util/readUtf8FileWithBom';
 import { DeploymentFileMapping } from './DeploymentFileMapping';
 
 const readAtMostBytesToFindParamsSchema = 4 * 1024;
@@ -39,11 +38,19 @@ interface IPossibleParameterFile {
 
 // tslint:disable-next-line: max-func-body-length
 export async function selectParameterFile(actionContext: IActionContext, mapping: DeploymentFileMapping, sourceUri: Uri | undefined): Promise<void> {
+  const editor = window.activeTextEditor;
   if (!sourceUri) {
     sourceUri = window.activeTextEditor?.document.uri;
   }
-  if (!sourceUri) {
-    await ext.ui.showWarningMessage(`No Azure Resource Manager template file is being edited.`);
+
+  if (!editor || !sourceUri || editor.document.uri.fsPath !== sourceUri.fsPath) {
+    await ext.ui.showWarningMessage(`Please open an Azure Resource Manager template file before trying to associate or create a parameter file.`);
+    return;
+
+  }
+  if (editor.document.languageId !== armTemplateLanguageId) {
+    actionContext.telemetry.properties.languageId = editor.document.languageId;
+    await ext.ui.showWarningMessage(`The current file "${sourceUri.fsPath}" does not appear to be an Azure Resource Manager Template. Please open one or make sure the editor Language Mode in the context menu is set to "Azure Resource Manager Template".`);
     return;
   }
 
@@ -54,12 +61,9 @@ export async function selectParameterFile(actionContext: IActionContext, mapping
     throw new Error("Please save the template file before associating it with a parameter file.");
   }
 
-  // Verify it's a template file (have to read in entire file to do full validation)
-  const contents = await readUtf8FileWithBom(templateUri.fsPath);
+  // Get the template file contents so we can find the top-level parameters
+  const contents = editor.document.getText(undefined);
   const template: DeploymentTemplate = new DeploymentTemplate(contents, templateUri);
-  if (!template.hasArmSchemaUri()) {
-    throw new Error(`"${templateUri.fsPath}" does not appear to be a valid Azure Resource Manager deployment template file.`);
-  }
 
   let quickPickList: IQuickPickList = await createParameterFileQuickPickList(mapping, templateUri);
   // Show the quick pick


### PR DESCRIPTION
I believe the problem was that the version of the template file on disk was empty or otherwise invalid, while the version in memory might have been valid.  Either way, we shouldn't be reading the file from disk, we should be getting the contents from the editor.

Also now simply validating that the editor language id is ours instead of throwing an error if the schema of the template is incorrect.

Fixes #838 
Fixes #852 