### PR TITLE
Fix 601 (Revision comparison states unexpected problems)

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -361,6 +361,10 @@ export class AzureRMTools {
     /**
      * Analyzes a text document that has been opened, and handles it appropriately if
      * it's a deployment template or parameter file
+     *
+     * NOTE: This method is called for *every* file opened in vscode, so we
+     * take extra care to avoid slowing down performance, especially if it's not
+     * an ARM template or parameter file.
      */
     private updateOpenedDocument(textDocument: vscode.TextDocument): void {
         // tslint:disable-next-line:no-suspicious-comment

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -323,14 +323,19 @@ export class AzureRMTools {
         });
     }
 
+    private getNormalizedDocumentKey(documentUri: vscode.Uri): string {
+        // We want a normalized file path to use as key, but also need to differentiate documents with different URI schemes
+        return `${documentUri.scheme}|${normalizePath(documentUri)}`;
+    }
     // Add the deployment doc to our list of opened deployment docs
     private setOpenedDeploymentDocument(documentUri: vscode.Uri, deploymentDocument: DeploymentDocument | undefined): void {
         assert(documentUri);
-        const normalizedPath = normalizePath(documentUri);
+        const documentPathKey = this.getNormalizedDocumentKey(documentUri);
+
         if (deploymentDocument) {
-            this._deploymentDocuments.set(normalizedPath, deploymentDocument);
+            this._deploymentDocuments.set(documentPathKey, deploymentDocument);
         } else {
-            this._deploymentDocuments.delete(normalizedPath);
+            this._deploymentDocuments.delete(documentPathKey);
         }
 
         this._codeLensChangedEmitter.fire();
@@ -339,8 +344,8 @@ export class AzureRMTools {
     private getOpenedDeploymentDocument(documentOrUri: vscode.TextDocument | vscode.Uri): DeploymentDocument | undefined {
         assert(documentOrUri);
         const uri = documentOrUri instanceof vscode.Uri ? documentOrUri : documentOrUri.uri;
-        const normalizedPath = normalizePath(uri);
-        return this._deploymentDocuments.get(normalizedPath);
+        const documentPathKey = this.getNormalizedDocumentKey(uri);
+        return this._deploymentDocuments.get(documentPathKey);
     }
 
     private getOpenedDeploymentTemplate(documentOrUri: vscode.TextDocument | vscode.Uri): DeploymentTemplate | undefined {

--- a/src/supported.ts
+++ b/src/supported.ts
@@ -39,6 +39,10 @@ function shouldWatchDocument(textDocument: TextDocument): boolean {
     if (
         textDocument.uri.scheme !== 'file'
         && textDocument.uri.scheme !== 'untitled' // unsaved files
+        // 'git' is the scheme that is used for documents in the left-hand side of the git 'changes'
+        // view.  If we don't switch to arm-template for it, the JSON language server will kick in
+        // and show false positive errors
+        && textDocument.uri.scheme !== 'git'
     ) {
         return false;
     }


### PR DESCRIPTION
Fixes #601

When we're shown in the git side-by-side display, the document scheme is changed to 'git', e.g. "git:/Users/xxx/template.json" instead of "file:/Users/xxx/template.json".  So two things:
1) Track changes in 'git' scheme URIs
2) Use full URI in our dictionary of templates, so the two URIs aren't treated the same