### PR TITLE
Support user-function parameter snippets

### DIFF
--- a/assets/armsnippets.jsonc
+++ b/assets/armsnippets.jsonc
@@ -1,11 +1,15 @@
 {
     /*
-        Known contexts:
+        Known contexts (see KnownSnippetContexts.ts)
 
         empty-document
         parameter-definitions
+        parameter-values
+        userfunc-parameter-definitions
 
-        Additionally, the name of the property containing the current array or object (e.g. "resources" or "outputs")
+        If a location in a template document does not match ones of the above, then it will
+        be set to the name of the property containing the current array or object (e.g. "resources" or "outputs"),
+        if any.
     */
     "$schema": "./schemas/snippets.schema.json",
     "Azure Resource Manager (ARM) Template": {
@@ -2477,7 +2481,6 @@
             "}"
         ],
         "description": "User-defined namespace and member function, should be placed inside a \"members\" object inside \"functions\"",
-        "$asdf": "asdf",
         "context": "members"
     },
     "User Function Namespace": {
@@ -2503,6 +2506,17 @@
         ],
         "description": "User-defined namespace and member function",
         "context": "functions"
+    },
+    "User Function Parameter Definition": {
+        "prefix": "new-userfunc-parameter",
+        "body": [
+            "{",
+            "\t\"name\": \"${1:parameter1}\",",
+            "\t\"type\": \"${2|string,securestring,int,bool,object,secureobject,array|}\"",
+            "}"
+        ],
+        "description": "ARM Template Parameter Definition",
+        "context": "userfunc-parameter-definitions"
     },
     "Virtual Network": {
         "prefix": "arm-vnet",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
         "onCommand:azurerm-vscode-tools.insertOutput",
         "onCommand:azurerm-vscode-tools.insertFunction",
         "onCommand:azurerm-vscode-tools.insertResource",
-        "onCommand:azurerm-vscode-tools.resetGlobalState"
+        "onCommand:azurerm-vscode-tools.developer.resetGlobalState",
+        "onCommand:azurerm-vscode-tools.developer.showSnippetContext"
     ],
     "contributes": {
         "grammars": [
@@ -170,16 +171,22 @@
         ],
         "commands": [
             {
-                "$comment": "============= Global/Treeview =============",
-                "category": "Azure Resource Manager Tools",
-                "title": "Reset Global State",
-                "command": "azurerm-vscode-tools.resetGlobalState"
+                "$comment": "============= Developer commands =============",
+                "category": "Azure Resource Manager Tools (Developer)",
+                "title": "Show Snippet Context at current location (for snippet authors)",
+                "command": "azurerm-vscode-tools.developer.showSnippetContext"
             },
             {
+                "category": "Azure Resource Manager Tools (Developer)",
+                "title": "Reset Global State",
+                "command": "azurerm-vscode-tools.developer.resetGlobalState"
+            },
+            {
+                "$comment": "============= Programmatic =============",
                 "category": "Azure Resource Manager Tools",
                 "title": "Go to parameter value",
                 "command": "azurerm-vscode-tools.codeLens.gotoParameterValue",
-                "$comment": "Code lens on a parameter definition - navigates to parameter value"
+                "$comment2": "Code lens on a parameter definition - navigates to parameter value"
             },
             {
                 "$comment": "============= Insert Item =============",

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -40,6 +40,7 @@ import { RenameCodeActionProvider } from "./RenameCodeActionProvider";
 import { resetGlobalState } from "./resetGlobalState";
 import { getPreferredSchema } from "./schemas";
 import { getFunctionParamUsage } from "./signatureFormatting";
+import { showSnippetContext } from "./snippets/showSnippetContext";
 import { SnippetManager } from "./snippets/SnippetManager";
 import { getQuickPickItems, sortTemplate } from "./sortTemplate";
 import { Stopwatch } from "./Stopwatch";
@@ -229,7 +230,6 @@ export class AzureRMTools {
         registerCommand("azurerm-vscode-tools.insertResource", async (actionContext: IActionContext) => {
             await this.insertItem(TemplateSectionType.Resources, actionContext);
         });
-        registerCommand("azurerm-vscode-tools.resetGlobalState", resetGlobalState);
 
         // Code action commands
         registerCommand("azurerm-vscode-tools.codeAction.addAllMissingParameters", async (actionContext: IActionContext, source?: vscode.Uri, args?: IAddMissingParametersArgs) => {
@@ -244,6 +244,21 @@ export class AzureRMTools {
             "azurerm-vscode-tools.codeLens.gotoParameterValue",
             async (actionContext: IActionContext, args: IGotoParameterValueArgs) => {
                 await this.onGotoParameterValue(actionContext, args);
+            });
+
+        // Developer commands
+        registerCommand("azurerm-vscode-tools.developer.resetGlobalState", resetGlobalState);
+        registerCommand(
+            "azurerm-vscode-tools.developer.showSnippetContext",
+            async (actionContext: IActionContext) => {
+                let editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
+                if (editor) {
+                    let position = editor.selection.anchor;
+                    let pc: PositionContext | undefined = await this.getPositionContext(editor.document, position, Cancellation.cantCancel);
+                    if (pc) {
+                        showSnippetContext(pc);
+                    }
+                }
             });
 
         this._paramsStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);

--- a/src/UserFunctionNamespaceDefinition.ts
+++ b/src/UserFunctionNamespaceDefinition.ts
@@ -4,6 +4,7 @@
 
 import * as os from 'os';
 import { CachedValue } from './CachedValue';
+import { templateKeys } from './constants';
 import { assert } from './fixed_assert';
 import { IUsageInfo } from './Hover';
 import { IJsonDocument } from "./IJsonDocument";
@@ -80,7 +81,7 @@ export class UserFunctionNamespaceDefinition implements INamedDefinition {
         return this._members.getOrCacheValue(() => {
             const membersResult: UserFunctionDefinition[] = [];
 
-            const members: Json.ObjectValue | undefined = Json.asObjectValue(this._value.getPropertyValue("members"));
+            const members: Json.ObjectValue | undefined = Json.asObjectValue(this._value.getPropertyValue(templateKeys.userFunctionMembers));
             if (members) {
                 for (let member of members.properties) {
                     let name: Json.StringValue = member.nameValue;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,4 +96,8 @@ export namespace templateKeys {
 
     // Linked templates
     export const linkedDeploymentTemplateLink = 'templateLink';
+
+    // User functions
+    export const userFunctionNamespace = 'namespace';
+    export const userFunctionMembers = 'members';
 }

--- a/src/insertItem.ts
+++ b/src/insertItem.ts
@@ -309,7 +309,8 @@ export class InsertItem {
             templatePart: topLevel,
             textEditor,
             data: functions,
-            name: "functions", indentLevel: 1
+            name: templateKeys.functions,
+            indentLevel: 1
         });
     }
 
@@ -329,7 +330,7 @@ export class InsertItem {
             templatePart: namespace,
             textEditor,
             data: members,
-            name: 'members',
+            name: templateKeys.userFunctionMembers,
             indentLevel: 3
         });
     }
@@ -362,7 +363,7 @@ export class InsertItem {
             context.errorHandling.suppressReportIssue = true;
             throw new Error("The first namespace in functions is not an object!");
         }
-        let members = namespace.getPropertyValue("members");
+        let members = namespace.getPropertyValue(templateKeys.userFunctionMembers);
         if (!members) {
             await this.insertFunctionAsMembers(namespace, textEditor);
             return;

--- a/src/snippets/SnippetContext.ts
+++ b/src/snippets/SnippetContext.ts
@@ -15,6 +15,11 @@ export enum KnownSnippetContexts {
     emptyDocument = 'empty-document',
 
     resources = 'resources',
+    // Parameter definitions, whether top-level or nested deployment
     parameterDefinitions = 'parameter-definitions',
+    // Parameter values, whether top-level or nested deployment
     parameterValues = 'parameter-values',
+
+    // User function parameter definitions
+    userFuncParameterDefinitions = 'userfunc-parameter-definitions',
 }

--- a/src/snippets/showSnippetContext.ts
+++ b/src/snippets/showSnippetContext.ts
@@ -1,0 +1,14 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------------------
+
+import { ext } from "../extensionVariables";
+import { PositionContext } from "../PositionContext";
+
+export function showSnippetContext(pc: PositionContext): void {
+    const insertionContext = pc.getSnippetInsertionContext(undefined);
+    ext.outputChannel.show();
+    const context = insertionContext.context ?? '(none)';
+    ext.outputChannel.appendLine(`Snippet context at ${pc.documentPosition.line + 1},${pc.documentPosition.column + 1}: ${context}`);
+
+}

--- a/test/functional/contextualizedSnippets.test.ts
+++ b/test/functional/contextualizedSnippets.test.ts
@@ -173,11 +173,13 @@ suite("Contextualized snippets", () => {
             []
         );
 
-        createContextualizedSnippetTest(
-            "top-level user function namespace",
-            "new-userfunc-namespace",
-            [undefined, '{'],
-            `{
+        suite("User functions", () => {
+
+            createContextualizedSnippetTest(
+                "top-level user function namespace",
+                "new-userfunc-namespace",
+                [undefined, '{'],
+                `{
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "resources": [
@@ -186,7 +188,7 @@ suite("Contextualized snippets", () => {
         !
     ]
 }`,
-            `{
+                `{
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "resources": [
@@ -211,17 +213,17 @@ suite("Contextualized snippets", () => {
         }
     ]
 }`,
-            [
-                "The user-defined function 'namespacename.functionname' is never used.",
-                "User-function parameter 'parametername' is never used."
-            ]
-        );
+                [
+                    "The user-defined function 'namespacename.functionname' is never used.",
+                    "User-function parameter 'parametername' is never used."
+                ]
+            );
 
-        createContextualizedSnippetTest(
-            "top-level user function",
-            "new-user-function",
-            [undefined, '"'],
-            `{
+            createContextualizedSnippetTest(
+                "top-level user function",
+                "new-user-function",
+                [undefined, '"'],
+                `{
                 "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "resources": [
@@ -247,7 +249,7 @@ suite("Contextualized snippets", () => {
                     }
                 ]
             }`,
-            `{
+                `{
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "resources": [
@@ -284,13 +286,76 @@ suite("Contextualized snippets", () => {
         }
     ]
 }`,
-            [
-                "The user-defined function 'namespacename.existingfunction' is never used.",
-                "The user-defined function 'namespacename.functionname' is never used.",
-                "User-function parameter 'parametername' is never used.",
-                "User-function parameter 'parametername' is never used."
-            ]
-        );
+                [
+                    "The user-defined function 'namespacename.existingfunction' is never used.",
+                    "The user-defined function 'namespacename.functionname' is never used.",
+                    "User-function parameter 'parametername' is never used.",
+                    "User-function parameter 'parametername' is never used."
+                ]
+            );
+
+            createContextualizedSnippetTest(
+                "User function parameters",
+                "new-userfunc-parameter",
+                [undefined, '{'],
+                `{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [],
+    "functions": [
+        {
+            "namespace": "namespacename",
+            "members": {
+                "functionname": {
+                    "parameters": [
+                        {
+                            "name": "parametername",
+                            "type": "string"
+                        },
+                        !
+                    ],
+                    "output": {
+                        "value": "function-return-value",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    ]
+}`,
+                `{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [],
+    "functions": [
+        {
+            "namespace": "namespacename",
+            "members": {
+                "functionname": {
+                    "parameters": [
+                        {
+                            "name": "parametername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parameter1",
+                            "type": "string"
+                        }
+                    ],
+                    "output": {
+                        "value": "function-return-value",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    ]
+}`,
+                [
+                ]
+            );
+
+        });
 
         createContextualizedSnippetTest(
             "top-level resource",

--- a/test/functional/contextualizedSnippets.test.ts
+++ b/test/functional/contextualizedSnippets.test.ts
@@ -352,6 +352,9 @@ suite("Contextualized snippets", () => {
     ]
 }`,
                 [
+                    "The user-defined function 'namespacename.functionname' is never used.",
+                    "User-function parameter 'parameter1' is never used.",
+                    "User-function parameter 'parametername' is never used."
                 ]
             );
 
@@ -812,5 +815,4 @@ suite("Contextualized snippets", () => {
 
     test('TODO: Child resources');
     test('TODO: subnets');
-    test('TODO: User function parameters');
 });

--- a/test/functional/snippets.test.ts
+++ b/test/functional/snippets.test.ts
@@ -98,7 +98,26 @@ const overrideTemplateForSnippet: { [name: string]: string } = {
 \t"resources": [
 \t\t//Insert here: resource
 \t]
-}`
+}`,
+
+    "User Function Parameter Definition": `{
+    "functions": [
+        {
+            "namespace": "udf",
+            "members": {
+                "func1": {
+                    "parameters": [
+                        //Insert here
+                    ],
+                    "output": {
+                        "type": "string",
+                        "value": "myvalue"
+                    }
+                }
+            }
+        }
+    ]
+}`,
 
 };
 
@@ -110,7 +129,8 @@ const overrideInsertPosition: { [name: string]: string } = {
     Parameter: "//Insert here: parameter",
     Output: "//Insert here: output",
     "User Function": "//Insert here: user function",
-    "User Function Namespace": "//Insert here: namespace"
+    "User Function Namespace": "//Insert here: namespace",
+    "User Function Parameter Definition": "//Insert here"
 };
 
 // Override expected errors/warnings for the snippet test - default is none
@@ -142,6 +162,12 @@ const overrideExpectedDiagnostics: { [name: string]: string[] } = {
     "User Function Namespace": [
         "The user-defined function 'namespacename.functionname' is never used.",
         "User-function parameter 'parametername' is never used."
+    ],
+    "User Function Parameter Definition": [
+        'Missing required property "$schema"',
+        "Template validation failed: Required property '$schema' not found in JSON. Path '', line 21, position 1.",
+        "The user-defined function 'udf.func1' is never used.",
+        "User-function parameter 'parameter1' is never used."
     ],
     "Automation Certificate": [
         // TODO: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1012620


### PR DESCRIPTION
Add a new snippet context for when we're inside a user-defined function parameter definitions object.

![userfunc params](https://user-images.githubusercontent.com/6913354/88225244-03eae680-cc1f-11ea-83bb-279cd6e94e31.gif)
