### PR TITLE
Support resource-body snippets like 'tags'

### DIFF
--- a/assets/armsnippets.jsonc
+++ b/assets/armsnippets.jsonc
@@ -6,6 +6,8 @@
         parameter-definitions
         parameter-values
         userfunc-parameter-definitions
+        resource-body
+
 
         If a location in a template document does not match ones of the above, then it will
         be set to the name of the property containing the current array or object (e.g. "resources" or "outputs"),
@@ -129,7 +131,7 @@
             "}"
         ],
         "description": "Tag Section",
-        "context": "asdf"
+        "context": "resource-body"
     },
     "Linked Deployment": {
         "prefix": "arm-linked-template",

--- a/src/snippets/SnippetContext.ts
+++ b/src/snippets/SnippetContext.ts
@@ -15,6 +15,10 @@ export enum KnownSnippetContexts {
     emptyDocument = 'empty-document',
 
     resources = 'resources',
+
+    // Inside the body of a single resource
+    resourceBody = 'resource-body',
+
     // Parameter definitions, whether top-level or nested deployment
     parameterDefinitions = 'parameter-definitions',
     // Parameter values, whether top-level or nested deployment

--- a/src/snippets/SnippetInsertionContext.ts
+++ b/src/snippets/SnippetInsertionContext.ts
@@ -33,5 +33,5 @@ export interface SnippetInsertionContext {
     /**
      * A list of all the JSON parents of the insertion point, going up the tree
      */
-    parents?: (Json.ObjectValue | Json.ArrayValue)[];
+    parents?: (Json.ObjectValue | Json.ArrayValue | Json.Property)[]; // CONSIDER: does this belong here?  It's only information about adding the snippet, not determining if it's supported
 }

--- a/test/functional/contextualizedSnippets.test.ts
+++ b/test/functional/contextualizedSnippets.test.ts
@@ -360,18 +360,19 @@ suite("Contextualized snippets", () => {
 
         });
 
-        createContextualizedSnippetTest(
-            "top-level resource",
-            "arm-web-app",
-            [undefined, '{'],
-            `{
+        suite("resources", () => {
+            createContextualizedSnippetTest(
+                "top-level resource",
+                "arm-web-app",
+                [undefined, '{'],
+                `{
                 "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "resources": [
                     !
                 ]
             }`,
-            `{
+                `{
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "resources": [
@@ -394,21 +395,21 @@ suite("Contextualized snippets", () => {
         }
     ]
 }`,
-            []
-        );
+                []
+            );
 
-        createContextualizedSnippetTest(
-            "top-level - multiple resources in one snippet",
-            "arm-vm-ubuntu",
-            [undefined, '{'],
-            `{
+            createContextualizedSnippetTest(
+                "top-level - multiple resources in one snippet",
+                "arm-vm-ubuntu",
+                [undefined, '{'],
+                `{
                 "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "resources": [
                     !
                 ]
             }`,
-            `{
+                `{
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "resources": [
@@ -573,8 +574,47 @@ suite("Contextualized snippets", () => {
         }
     ]
 }`,
-            []
-        );
+                []
+            );
+
+            createContextualizedSnippetTest(
+                "resource tags",
+                "arm-tags",
+                [undefined, '"'],
+                `{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "name": "webApp1",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2018-11-01",
+            !
+        }
+    ]
+}`,
+                `{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "name": "webApp1",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2018-11-01",
+            "tags": {
+                "tagName": "tagValue"
+            }
+        }
+    ]
+}`,
+                [
+                    "Missing required property \"location\"",
+                    "Missing required property \"properties\""
+                ]
+            );
+
+        });
+
     });
 
     suite('Nested templates', () => {

--- a/test/functional/contextualizedSnippets.test.ts
+++ b/test/functional/contextualizedSnippets.test.ts
@@ -11,6 +11,7 @@ const DEBUG_BREAK_AFTER_INSERTING_SNIPPET = false;
 
 import * as assert from 'assert';
 import { Position, Selection } from "vscode";
+import { testLog } from '../support/createTestLog';
 import { delay } from '../support/delay';
 import { diagnosticSources, getDiagnosticsForDocument, IGetDiagnosticsOptions } from '../support/diagnostics';
 import { formatDocumentAndWait } from '../support/formatDocumentAndWait';
@@ -57,6 +58,9 @@ suite("Contextualized snippets", () => {
                     // Insert snippet (and wait for and verify diagnotics)
                     const docPos = dt.getDocumentPosition(bang.index);
                     const pos = new Position(docPos.line, docPos.line);
+
+                    testLog.writeLine(`Document before inserting snippet:\n${tempEditor.document.realDocument.getText()}`);
+
                     tempEditor.realEditor.selection = new Selection(pos, pos);
                     await delay(1);
                     await simulateCompletion(
@@ -76,6 +80,7 @@ suite("Contextualized snippets", () => {
 
                     // Format (vscode seems to be inconsistent about this in these scenarios)
                     const docTextAfterInsertion = await formatDocumentAndWait(tempDoc.realDocument);
+                    testLog.writeLine(`Document after inserting snippet:\n${docTextAfterInsertion}`);
                     assert.equal(docTextAfterInsertion, expectedTemplate);
 
                     // Compare diagnostics
@@ -608,8 +613,6 @@ suite("Contextualized snippets", () => {
     ]
 }`,
                 [
-                    "Missing required property \"location\"",
-                    "Missing required property \"properties\""
                 ]
             );
 

--- a/test/functional/snippets.test.ts
+++ b/test/functional/snippets.test.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import * as stripJsonComments from 'strip-json-comments';
 import { commands, Selection, Uri, window, workspace } from "vscode";
 import { DeploymentTemplate, getVSCodePositionFromPosition } from '../../extension.bundle';
+import { testLog } from '../support/createTestLog';
 import { delay } from '../support/delay';
 import { diagnosticSources, getDiagnosticsForDocument, IGetDiagnosticsOptions } from '../support/diagnostics';
 import { formatDocumentAndWait } from '../support/formatDocumentAndWait';
@@ -468,6 +469,7 @@ suite("Snippets functional tests", () => {
 
         // Insert snippet
         const docTextBeforeInsertion = doc.getText();
+        testLog.writeLine(`Document before inserting snippet:\n${docTextBeforeInsertion}`);
         await simulateCompletion(
             editor,
             snippet.prefix,
@@ -484,6 +486,7 @@ suite("Snippets functional tests", () => {
 
         // Format (vscode seems to be inconsistent about this in these scenarios)
         const docTextAfterInsertion = await formatDocumentAndWait(doc);
+        testLog.writeLine(`Document after inserting snippet:\n${docTextAfterInsertion}`);
         validateDocumentWithSnippet();
 
         // Compare diagnostics

--- a/test/support/diagnostics.ts
+++ b/test/support/diagnostics.ts
@@ -402,7 +402,7 @@ export async function getDiagnosticsForDocument(
         clearTimeout(timer);
     }
 
-    testLog.writeLine(`Diagnostics comlete:  ${stringify(diagnostics)}`);
+    testLog.writeLine(`Diagnostics complete:  ${stringify(diagnostics)}`);
 
     // Verify the version of expectedMinimumVersionForEachSource
     for (const source of Object.getOwnPropertyNames(diagnostics.sourceCompletionVersions)) {


### PR DESCRIPTION
Depends on https://github.com/microsoft/vscode-azurearmtools/pull/867 - review anything after the first commit

Fixes part of #654 

Adds a new snippet context "resource-body" that indicates the current position is inside a resource's body, and use that for the "tags" snippet.