### PR TITLE
Fix 891, warnings not showing for parameter values for outer-scoped n…

### DIFF
--- a/src/DeploymentTemplate.ts
+++ b/src/DeploymentTemplate.ts
@@ -286,7 +286,7 @@ export class DeploymentTemplate extends DeploymentDocument {
 
                 const propertyValues = scope.parameterValuesProperty;
                 // tslint:disable-next-line: strict-boolean-expressions
-                if (!!propertyValues?.asArrayValue?.elements.length) {
+                if (!!propertyValues?.value?.asObjectValue?.properties.length) {
                     warnings.push(
                         new language.Issue(propertyValues.span, warningMessage, language.IssueKind.inaccessibleNestedScopeMembers));
                 }


### PR DESCRIPTION
…ested template

Fixes #894 

We were incorrectly treating the parameters object as an array.  Not sure how that happened, since the testcase I created for it had it working correctly in the screenshot.  Oh, well...