### PR TITLE
TLE shouldn't depend on TemplateScope

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -21,7 +21,7 @@ import * as basic from "./src/language/json/Tokenizer";
 import * as Completion from './src/vscodeIntegration/Completion';
 
 export { activateInternal, deactivateInternal } from './src/AzureRMTools'; // Export activate/deactivate for main.js
-export { armTemplateLanguageId, basePath, configKeys, configPrefix, diagnosticsCompletePrefix, expressionsDiagnosticsSource, isWin32, languageServerStateSource, templateKeys } from "./src/constants";
+export * from "./src/constants";
 export { DeploymentFileMapping } from "./src/documents/parameters/DeploymentFileMapping";
 export { DeploymentParametersDoc } from "./src/documents/parameters/DeploymentParametersDoc";
 export { IParameterDefinition } from "./src/documents/parameters/IParameterDefinition";
@@ -50,6 +50,7 @@ export { UserFunctionParameterDefinition } from "./src/documents/templates/UserF
 export { isVariableDefinition, IVariableDefinition } from "./src/documents/templates/VariableDefinition";
 export { ext } from './src/extensionVariables';
 export * from './src/language/expressions/AzureRMAssets';
+export * from "./src/language/expressions/isTleExpression";
 export { FunctionSignatureHelp, TleParseResult } from "./src/language/expressions/TLE";
 export { DefinitionKind, INamedDefinition } from "./src/language/INamedDefinition";
 export { Issue } from "./src/language/Issue";

--- a/src/documents/parameters/DeploymentFileMapping.ts
+++ b/src/documents/parameters/DeploymentFileMapping.ts
@@ -8,7 +8,7 @@ import { ConfigurationTarget, Uri } from 'vscode';
 import { configKeys } from '../../constants';
 import { normalizePath } from '../../util/normalizePath';
 import { IConfiguration } from '../../vscodeIntegration/Configuration';
-import { getRelativeParameterFilePath, resolveParameterFilePath } from './parameterFiles';
+import { getRelativeParameterFilePath, resolveParameterFilePath } from './parameterFilePaths';
 
 interface IMapping {
     // Path using same casing as specified (but /.. and double slashes normalized).

--- a/src/documents/parameters/parameterFileGeneration.ts
+++ b/src/documents/parameters/parameterFileGeneration.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { QuickPickItem, Uri, window } from "vscode";
 import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
-import { isTleExpression } from '../../language/expressions/TLE';
+import { isTleExpression } from "../../language/expressions/isTleExpression";
 import * as Json from "../../language/json/JSON";
 import { assertNever } from '../../util/assertNever';
 import { CaseInsensitiveMap } from '../../util/CaseInsensitiveMap';

--- a/src/documents/parameters/parameterFilePaths.ts
+++ b/src/documents/parameters/parameterFilePaths.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.md in the project root for license information.
+// ---------------------------------------------------------------------------------------------
+
+import * as assert from "assert";
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { normalizePath } from '../../util/normalizePath';
+
+export function getRelativeParameterFilePath(templateUri: Uri, parameterUri: Uri): string {
+    const templatePath = normalizePath(templateUri);
+    const paramPath = normalizePath(parameterUri);
+
+    return path.relative(path.dirname(templatePath), paramPath);
+}
+
+export function resolveParameterFilePath(templatePath: string, parameterPathRelativeToTemplate: string): string {
+    assert(path.isAbsolute(templatePath));
+    const resolved = path.resolve(path.dirname(templatePath), parameterPathRelativeToTemplate);
+    return resolved;
+}

--- a/src/documents/parameters/parameterFiles.ts
+++ b/src/documents/parameters/parameterFiles.ts
@@ -16,6 +16,7 @@ import { DeploymentTemplateDoc } from '../templates/DeploymentTemplateDoc';
 import { documentSchemes } from '../templates/supported';
 import { DeploymentFileMapping } from './DeploymentFileMapping';
 import { queryCreateParameterFile } from './parameterFileGeneration';
+import { getRelativeParameterFilePath } from './parameterFilePaths';
 
 const readAtMostBytesToFindParamsSchema = 4 * 1024;
 const currentMessage = "Current";
@@ -171,19 +172,6 @@ export function getFriendlyPathToFile(uri: Uri): string {
   } else {
     return uri.fsPath;
   }
-}
-
-export function getRelativeParameterFilePath(templateUri: Uri, parameterUri: Uri): string {
-  const templatePath = normalizePath(templateUri);
-  const paramPath = normalizePath(parameterUri);
-
-  return path.relative(path.dirname(templatePath), paramPath);
-}
-
-export function resolveParameterFilePath(templatePath: string, parameterPathRelativeToTemplate: string): string {
-  assert(path.isAbsolute(templatePath));
-  const resolved = path.resolve(path.dirname(templatePath), parameterPathRelativeToTemplate);
-  return resolved;
 }
 
 interface IQuickPickList {

--- a/src/documents/positionContexts/TemplatePositionContext.ts
+++ b/src/documents/positionContexts/TemplatePositionContext.ts
@@ -85,8 +85,8 @@ export class TemplatePositionContext extends PositionContext {
             ) {
                 const tleParseResult = this.document.getTLEParseResultFromJsonStringValue(this.jsonValue);
                 const tleCharacterIndex = this.documentCharacterIndex - this.jsonTokenStartIndex;
-                const tleValue = tleParseResult.getValueAtCharacterIndex(tleCharacterIndex);
-                return new TleInfo(tleParseResult, tleCharacterIndex, tleValue, tleParseResult.scope);
+                const tleValue = tleParseResult.parseResult.getValueAtCharacterIndex(tleCharacterIndex);
+                return new TleInfo(tleParseResult.parseResult, tleCharacterIndex, tleValue, tleParseResult.scope);
             }
             return undefined;
         });

--- a/src/documents/templates/deploymentTemplateCodeLenses.ts
+++ b/src/documents/templates/deploymentTemplateCodeLenses.ts
@@ -14,7 +14,7 @@ import { ResolvableCodeLens } from '../DeploymentDocument';
 import { IParameterDefinition } from '../parameters/IParameterDefinition';
 import { IParameterValuesSource } from '../parameters/IParameterValuesSource';
 import { IParameterValuesSourceProvider } from '../parameters/IParameterValuesSourceProvider';
-import { getRelativeParameterFilePath } from '../parameters/parameterFiles';
+import { getRelativeParameterFilePath } from "../parameters/parameterFilePaths";
 import { TemplateScope, TemplateScopeKind } from './scopes/TemplateScope';
 import { TopLevelTemplateScope } from './scopes/templateScopes';
 

--- a/src/documents/templates/getDependsOnCompletions.ts
+++ b/src/documents/templates/getDependsOnCompletions.ts
@@ -6,7 +6,7 @@
 import { MarkdownString } from "vscode";
 import { templateKeys } from "../../constants";
 import { assert } from "../../fixed_assert";
-import { isTleExpression } from "../../language/expressions/TLE";
+import { isTleExpression } from "../../language/expressions/isTleExpression";
 import * as Json from "../../language/json/JSON";
 import { ContainsBehavior, Span } from "../../language/Span";
 import { isSingleQuoted, removeSingleQuotes } from "../../util/strings";

--- a/src/documents/templates/getResourcesInfo.ts
+++ b/src/documents/templates/getResourcesInfo.ts
@@ -288,7 +288,7 @@ export function splitResourceNameIntoSegments(nameUnquotedValue: string, scope: 
         // No sense taking time for parsing if '/' is nowhere in the expression
         if (nameUnquotedValue.includes('/')) {
             const quotedValue = `"${nameUnquotedValue}"`;
-            const parseResult = TLE.Parser.parse(quotedValue, scope);
+            const parseResult = TLE.Parser.parse(quotedValue);
             const expression = parseResult.expression;
             if (parseResult.errors.length === 0 && expression) {
                 // Handle this pattern:

--- a/src/language/expressions/isTleExpression.ts
+++ b/src/language/expressions/isTleExpression.ts
@@ -1,0 +1,10 @@
+// ---------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.md in the project root for license information.
+// ---------------------------------------------------------------------------------------------
+
+export function isTleExpression(unquotedStringValue: string): boolean {
+    // An expression must start with '[' (no whitespace before),
+    //   not start with '[[', and end with ']' (no whitespace after)
+    return !!unquotedStringValue.match(/^\[(?!\[).*\]$/);
+}

--- a/src/visitors/FindReferencesVisitor.ts
+++ b/src/visitors/FindReferencesVisitor.ts
@@ -4,6 +4,7 @@
 
 import { templateKeys } from "../constants";
 import { DeploymentDocument } from "../documents/DeploymentDocument";
+import { TemplateScope } from "../documents/templates/scopes/TemplateScope";
 import { UserFunctionDefinition } from "../documents/templates/UserFunctionDefinition";
 import { UserFunctionNamespaceDefinition } from "../documents/templates/UserFunctionNamespaceDefinition";
 import { assert } from '../fixed_assert';
@@ -23,6 +24,7 @@ export class FindReferencesVisitor extends Visitor {
 
     constructor(
         private readonly _document: DeploymentDocument,
+        private readonly _scope: TemplateScope,
         private readonly _definition: INamedDefinition,
         private readonly _functionsMetadata: FunctionsMetadata
     ) {
@@ -54,7 +56,7 @@ export class FindReferencesVisitor extends Visitor {
         switch (this._definition.definitionKind) {
             case DefinitionKind.UserFunction:
                 if (tleFunction.nameToken && tleFunction.name && tleFunction.namespace) {
-                    const userFunctionDefinition: UserFunctionDefinition | undefined = tleFunction.scope.getUserFunctionDefinition(tleFunction.namespace, tleFunction.name);
+                    const userFunctionDefinition: UserFunctionDefinition | undefined = this._scope.getUserFunctionDefinition(tleFunction.namespace, tleFunction.name);
                     if (userFunctionDefinition === this._definition) {
                         this.addReference(tleFunction.nameToken.span);
                     }
@@ -63,7 +65,7 @@ export class FindReferencesVisitor extends Visitor {
 
             case DefinitionKind.Namespace:
                 if (tleFunction.namespaceToken && tleFunction.namespace) {
-                    const userNamespaceDefinition: UserFunctionNamespaceDefinition | undefined = tleFunction.scope.getFunctionNamespaceDefinition(tleFunction.namespace);
+                    const userNamespaceDefinition: UserFunctionNamespaceDefinition | undefined = this._scope.getFunctionNamespaceDefinition(tleFunction.namespace);
                     if (userNamespaceDefinition === this._definition) {
                         this.addReference(tleFunction.namespaceToken.span);
                     }
@@ -90,7 +92,7 @@ export class FindReferencesVisitor extends Visitor {
                         const arg = tleFunction.argumentExpressions[0];
                         if (arg instanceof StringValue) {
                             const argName = arg.toString();
-                            const paramDefinition = tleFunction.scope.getParameterDefinition(argName);
+                            const paramDefinition = this._scope.getParameterDefinition(argName);
                             if (paramDefinition === this._definition) {
                                 this.addReference(arg.unquotedSpan);
                             }
@@ -105,7 +107,7 @@ export class FindReferencesVisitor extends Visitor {
                         const arg = tleFunction.argumentExpressions[0];
                         if (arg instanceof StringValue) {
                             const argName = arg.toString();
-                            const varDefinition = tleFunction.scope.getVariableDefinition(argName);
+                            const varDefinition = this._scope.getVariableDefinition(argName);
                             if (varDefinition === this._definition) {
                                 this.addReference(arg.unquotedSpan);
                             }
@@ -126,8 +128,8 @@ export class FindReferencesVisitor extends Visitor {
         super.visitFunctionCall(tleFunction);
     }
 
-    public static visit(document: DeploymentDocument, tleValue: Value | undefined, definition: INamedDefinition, metadata: FunctionsMetadata): FindReferencesVisitor {
-        const visitor = new FindReferencesVisitor(document, definition, metadata);
+    public static visit(document: DeploymentDocument, scope: TemplateScope, tleValue: Value | undefined, definition: INamedDefinition, metadata: FunctionsMetadata): FindReferencesVisitor {
+        const visitor = new FindReferencesVisitor(document, scope, definition, metadata);
         if (tleValue) {
             tleValue.accept(visitor);
         }

--- a/src/visitors/IncorrectFunctionArgumentCountVisitor.ts
+++ b/src/visitors/IncorrectFunctionArgumentCountVisitor.ts
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 import { isNullOrUndefined } from "util";
+import { TemplateScope } from "../documents/templates/scopes/TemplateScope";
 import { UserFunctionNamespaceDefinition } from "../documents/templates/UserFunctionNamespaceDefinition";
 import { assert } from "../fixed_assert";
 import * as assets from "../language/expressions/AzureRMAssets";
@@ -16,7 +17,7 @@ import { IncorrectArgumentsCountIssue } from "./IncorrectArgumentsCountIssue";
 export class IncorrectFunctionArgumentCountVisitor extends Visitor {
     private _errors: IncorrectArgumentsCountIssue[] = [];
 
-    constructor(private _tleFunctions: assets.FunctionsMetadata) {
+    constructor(private readonly _scope: TemplateScope, private readonly _tleFunctions: assets.FunctionsMetadata) {
         super();
     }
 
@@ -36,7 +37,7 @@ export class IncorrectFunctionArgumentCountVisitor extends Visitor {
 
         if (tleFunction.namespaceToken) {
             const namespaceName: string = tleFunction.namespaceToken.stringValue.toString();
-            const nsDefinition: UserFunctionNamespaceDefinition | undefined = tleFunction.scope.getFunctionNamespaceDefinition(namespaceName);
+            const nsDefinition: UserFunctionNamespaceDefinition | undefined = this._scope.getFunctionNamespaceDefinition(namespaceName);
 
             // If not found, will be handled by the UnrecognizedFunctionVisitor visitor
             if (!nsDefinition) {
@@ -97,8 +98,8 @@ export class IncorrectFunctionArgumentCountVisitor extends Visitor {
         return `argument${argumentCount === 1 ? "" : "s"}`;
     }
 
-    public static visit(tleValue: Value | undefined, tleFunctions: assets.FunctionsMetadata): IncorrectFunctionArgumentCountVisitor {
-        const visitor = new IncorrectFunctionArgumentCountVisitor(tleFunctions);
+    public static visit(scope: TemplateScope, tleValue: Value | undefined, tleFunctions: assets.FunctionsMetadata): IncorrectFunctionArgumentCountVisitor {
+        const visitor = new IncorrectFunctionArgumentCountVisitor(scope, tleFunctions);
         if (tleValue) {
             tleValue.accept(visitor);
         }

--- a/src/visitors/ReferenceInVariableDefinitionsVisitor.ts
+++ b/src/visitors/ReferenceInVariableDefinitionsVisitor.ts
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ----------------------------------------------------------------------------
 
-import { DeploymentTemplateDoc } from "../documents/templates/DeploymentTemplateDoc";
+import { DeploymentTemplateDoc, IScopedParseResult } from "../documents/templates/DeploymentTemplateDoc";
 import { assert } from '../fixed_assert';
 import * as TLE from "../language/expressions/TLE";
 import * as Json from "../language/json/JSON";
@@ -28,10 +28,10 @@ export class ReferenceInVariableDefinitionsVisitor extends Json.Visitor {
     public visitStringValue(value: Json.StringValue): void {
         assert(value, "Cannot visit a null or undefined Json.StringValue.");
 
-        const tleParseResult: TLE.TleParseResult = this._deploymentTemplate.getTLEParseResultFromJsonStringValue(value);
-        if (tleParseResult.expression) {
+        const tleParseResult: IScopedParseResult = this._deploymentTemplate.getTLEParseResultFromJsonStringValue(value);
+        if (tleParseResult.parseResult.expression) {
             const tleVisitor = new ReferenceInVariableDefinitionTLEVisitor();
-            tleParseResult.expression.accept(tleVisitor);
+            tleParseResult.parseResult.expression.accept(tleVisitor);
 
             const jsonValueStartIndex: number = value.startIndex;
             for (const tleReferenceSpan of tleVisitor.referenceSpans) {

--- a/test/FunctionCountVisitor.test.ts
+++ b/test/FunctionCountVisitor.test.ts
@@ -6,15 +6,11 @@
 // tslint:disable:no-non-null-assertion object-literal-key-quotes variable-name
 
 import * as assert from "assert";
-import { Uri } from "vscode";
-import { DeploymentTemplateDoc, FunctionCountVisitor, Histogram, TemplateScope, TLE, TopLevelTemplateScope } from "../extension.bundle";
+import { FunctionCountVisitor, Histogram, TLE } from "../extension.bundle";
 
 suite("FunctionCountVisitor", () => {
-    const dt = new DeploymentTemplateDoc("", Uri.file("/doc"));
-    const emptyScope: TemplateScope = new TopLevelTemplateScope(dt, undefined, "empty");
-
     function testFunctionCountsVisitor(expressionWithoutQuotes: string, expectedFunctionCounts: { [key: string]: number }): void {
-        const tleParseResult = TLE.Parser.parse(`"${expressionWithoutQuotes}"`, emptyScope);
+        const tleParseResult = TLE.Parser.parse(`"${expressionWithoutQuotes}"`);
         const visitor = FunctionCountVisitor.visit(tleParseResult.expression);
 
         const expected = new Histogram();

--- a/test/TLE.test.ts
+++ b/test/TLE.test.ts
@@ -7,8 +7,7 @@
 
 import * as assert from "assert";
 import { Uri } from "vscode";
-import { AzureRMAssets, BuiltinFunctionMetadata, DefinitionKind, DeploymentTemplateDoc, FindReferencesVisitor, FunctionsMetadata, IncorrectArgumentsCountIssue, IncorrectFunctionArgumentCountVisitor, Issue, IssueKind, nonNullValue, ReferenceList, Span, TemplatePositionContext, TLE, TopLevelTemplateScope, UndefinedParameterAndVariableVisitor, UndefinedVariablePropertyVisitor, UnrecognizedBuiltinFunctionIssue, UnrecognizedFunctionVisitor } from "../extension.bundle";
-import { isTleExpression } from "../src/language/expressions/isTleExpression";
+import { AzureRMAssets, BuiltinFunctionMetadata, DefinitionKind, DeploymentTemplateDoc, FindReferencesVisitor, FunctionsMetadata, IncorrectArgumentsCountIssue, IncorrectFunctionArgumentCountVisitor, Issue, IssueKind, isTleExpression, nonNullValue, ReferenceList, Span, TemplatePositionContext, TLE, TopLevelTemplateScope, UndefinedParameterAndVariableVisitor, UndefinedVariablePropertyVisitor, UnrecognizedBuiltinFunctionIssue, UnrecognizedFunctionVisitor } from "../extension.bundle";
 import { IDeploymentTemplate } from "./support/diagnostics";
 import { parseTemplate } from "./support/parseTemplate";
 

--- a/test/TLE.test.ts
+++ b/test/TLE.test.ts
@@ -7,7 +7,8 @@
 
 import * as assert from "assert";
 import { Uri } from "vscode";
-import { AzureRMAssets, BuiltinFunctionMetadata, DefinitionKind, DeploymentTemplateDoc, FindReferencesVisitor, FunctionsMetadata, IncorrectArgumentsCountIssue, IncorrectFunctionArgumentCountVisitor, Issue, IssueKind, nonNullValue, ReferenceList, Span, TemplatePositionContext, TemplateScope, TLE, TopLevelTemplateScope, UndefinedParameterAndVariableVisitor, UndefinedVariablePropertyVisitor, UnrecognizedBuiltinFunctionIssue, UnrecognizedFunctionVisitor } from "../extension.bundle";
+import { AzureRMAssets, BuiltinFunctionMetadata, DefinitionKind, DeploymentTemplateDoc, FindReferencesVisitor, FunctionsMetadata, IncorrectArgumentsCountIssue, IncorrectFunctionArgumentCountVisitor, Issue, IssueKind, nonNullValue, ReferenceList, Span, TemplatePositionContext, TLE, TopLevelTemplateScope, UndefinedParameterAndVariableVisitor, UndefinedVariablePropertyVisitor, UnrecognizedBuiltinFunctionIssue, UnrecognizedFunctionVisitor } from "../extension.bundle";
+import { isTleExpression } from "../src/language/expressions/isTleExpression";
 import { IDeploymentTemplate } from "./support/diagnostics";
 import { parseTemplate } from "./support/parseTemplate";
 
@@ -18,15 +19,14 @@ const fakeId = Uri.file("https://fake-id");
 suite("TLE", () => {
     const emptyScope = new TopLevelTemplateScope(new DeploymentTemplateDoc("", Uri.file("/doc")), undefined, "empty scope");
 
-    function parseExpressionWithScope(stringValue: string, scope?: TemplateScope): TLE.TleParseResult {
-        scope = scope ? scope : emptyScope;
-        return TLE.Parser.parse(stringValue, scope);
+    function parseExpression(stringValue: string): TLE.TleParseResult {
+        return TLE.Parser.parse(stringValue);
     }
 
     suite("isExpression", () => {
         function createIsExpressionTest(unquotedValue: string, expectedResult: boolean): void {
             test(`"${unquotedValue}"`, () => {
-                const result = TLE.isTleExpression(unquotedValue);
+                const result = isTleExpression(unquotedValue);
                 assert.equal(result, expectedResult);
             });
         }
@@ -264,7 +264,7 @@ suite("TLE", () => {
                 let commaTokens: TLE.Token[] = [];
                 let args: (TLE.Value | undefined)[] = [];
                 let rightParenthesis = TLE.Token.createRightParenthesis(10);
-                let f = new TLE.FunctionCallValue(undefined, undefined, name, leftParenthesis, commaTokens, args, rightParenthesis, emptyScope);
+                let f = new TLE.FunctionCallValue(undefined, undefined, name, leftParenthesis, commaTokens, args, rightParenthesis);
                 assert.deepStrictEqual(name, f.nameToken);
                 assert.deepStrictEqual(leftParenthesis, f.leftParenthesisToken);
                 assert.deepStrictEqual(args, f.argumentExpressions);
@@ -279,7 +279,7 @@ suite("TLE", () => {
                 let args: (TLE.Value | undefined)[] = [];
                 let rightParenthesis = TLE.Token.createRightParenthesis(10);
 
-                let f = new TLE.FunctionCallValue(undefined, undefined, name, undefined, commaTokens, args, rightParenthesis, emptyScope);
+                let f = new TLE.FunctionCallValue(undefined, undefined, name, undefined, commaTokens, args, rightParenthesis);
 
                 assert.deepStrictEqual(name, f.nameToken);
                 assert.deepStrictEqual(undefined, f.leftParenthesisToken);
@@ -294,7 +294,7 @@ suite("TLE", () => {
                 let rightParenthesis = TLE.Token.createRightParenthesis(10);
 
                 // tslint:disable-next-line:no-any
-                assert.throws(() => { new TLE.FunctionCallValue(undefined, undefined, name, leftParenthesis, commaTokens, <any>undefined, rightParenthesis, emptyScope); });
+                assert.throws(() => { new TLE.FunctionCallValue(undefined, undefined, name, leftParenthesis, commaTokens, <any>undefined, rightParenthesis); });
             });
 
             test("with undefined _rightParenthesisToken", () => {
@@ -303,7 +303,7 @@ suite("TLE", () => {
                 let leftParenthesis = TLE.Token.createLeftParenthesis(5);
                 let args: (TLE.Value | undefined)[] = [];
 
-                let f = new TLE.FunctionCallValue(undefined, undefined, name, leftParenthesis, commaTokens, args, undefined, emptyScope);
+                let f = new TLE.FunctionCallValue(undefined, undefined, name, leftParenthesis, commaTokens, args, undefined);
 
                 assert.deepStrictEqual(name, f.nameToken);
                 assert.deepStrictEqual(leftParenthesis, f.leftParenthesisToken);
@@ -314,43 +314,43 @@ suite("TLE", () => {
 
         suite("getSpan()", () => {
             test("with name", () => {
-                let f = parseExpressionWithScope("\"[concat]\"").expression;
+                let f = parseExpression("\"[concat]\"").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 6), f!.getSpan());
             });
 
             test("with left parenthesis", () => {
-                let f = parseExpressionWithScope("\"[concat(]\"").expression;
+                let f = parseExpression("\"[concat(]\"").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 7), f!.getSpan());
             });
 
             test("with one argument and no right parenthesis", () => {
-                let f = parseExpressionWithScope("\"[concat(70").expression;
+                let f = parseExpression("\"[concat(70").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 9), f!.getSpan());
             });
 
             test("with two arguments and no right parenthesis", () => {
-                let f = parseExpressionWithScope("\"[concat(70, 3").expression;
+                let f = parseExpression("\"[concat(70, 3").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 12), f!.getSpan());
             });
 
             test("with left and right parenthesis and no arguments", () => {
-                let f = parseExpressionWithScope("\"[concat()\"").expression;
+                let f = parseExpression("\"[concat()\"").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 8), f!.getSpan());
             });
 
             test("with left and right parenthesis and arguments", () => {
-                let f = parseExpressionWithScope("\"[concat('hello', 'world')\"").expression;
+                let f = parseExpression("\"[concat('hello', 'world')\"").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 24), f!.getSpan());
             });
 
             test("with last argument missing and no right parenthesis", () => {
-                let f = parseExpressionWithScope("\"[concat('hello',").expression;
+                let f = parseExpression("\"[concat('hello',").expression;
                 assert(f instanceof TLE.FunctionCallValue);
                 assert.deepStrictEqual(new Span(2, 15), f!.getSpan());
             });
@@ -450,8 +450,7 @@ suite("TLE", () => {
                     undefined,
                     [],
                     [stringValue],
-                    undefined,
-                    dt.topLevelScope);
+                    undefined);
 
                 visitor.visitString(stringValue);
                 assert.deepStrictEqual(
@@ -474,8 +473,7 @@ suite("TLE", () => {
                     undefined,
                     [],
                     [stringValue],
-                    undefined,
-                    dt.topLevelScope);
+                    undefined);
 
                 visitor.visitString(stringValue);
                 assert.deepStrictEqual(
@@ -491,15 +489,15 @@ suite("TLE", () => {
     suite("Parser", () => {
         suite("parse(string)", () => {
             test("with empty stringValue", () => {
-                assert.throws(() => { parseExpressionWithScope(""); });
+                assert.throws(() => { parseExpression(""); });
             });
 
             test("with non-empty non-quoted stringValue", () => {
-                assert.throws(() => { parseExpressionWithScope("hello"); });
+                assert.throws(() => { parseExpression("hello"); });
             });
 
             test("with single double-quote character", () => {
-                let pr = parseExpressionWithScope("\"");
+                let pr = parseExpression("\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -510,7 +508,7 @@ suite("TLE", () => {
             });
 
             test("with empty quoted string", () => {
-                let pr = parseExpressionWithScope("\"\"");
+                let pr = parseExpression("\"\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -521,7 +519,7 @@ suite("TLE", () => {
             });
 
             test("with non-empty quoted string", () => {
-                let pr = parseExpressionWithScope("\"hello\"");
+                let pr = parseExpression("\"hello\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -532,7 +530,7 @@ suite("TLE", () => {
             });
 
             test("with left square bracket (but no right square bracket)", () => {
-                let pr = parseExpressionWithScope("\"[\"");
+                let pr = parseExpression("\"[\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.equal(undefined, pr.expression);
@@ -546,7 +544,7 @@ suite("TLE", () => {
             });
 
             test("with two left square brackets", () => {
-                let pr = parseExpressionWithScope("\"[[\"");
+                let pr = parseExpression("\"[[\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -557,7 +555,7 @@ suite("TLE", () => {
             });
 
             test("with two left square brackets and a right square bracket", () => {
-                let pr = parseExpressionWithScope("\"[[]\"");
+                let pr = parseExpression("\"[[]\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -568,7 +566,7 @@ suite("TLE", () => {
             });
 
             test("with two left square brackets and a literal", () => {
-                let pr = parseExpressionWithScope("\"[[hello\"");
+                let pr = parseExpression("\"[[hello\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -579,7 +577,7 @@ suite("TLE", () => {
             });
 
             test("with left and right square brackets", () => {
-                let pr = parseExpressionWithScope("\"[]\"");
+                let pr = parseExpression("\"[]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.equal(undefined, pr.expression);
@@ -590,7 +588,7 @@ suite("TLE", () => {
             });
 
             test("with left and right square brackets after whitespace", () => {
-                let pr = parseExpressionWithScope("\"  []\"");
+                let pr = parseExpression("\"  []\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(3), pr.leftSquareBracketToken);
                 assert.equal(undefined, pr.expression);
@@ -601,7 +599,7 @@ suite("TLE", () => {
             });
 
             test("with left and right square brackets with whitespace between them", () => {
-                let pr = parseExpressionWithScope("\"[    ]\"");
+                let pr = parseExpression("\"[    ]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(undefined, pr.expression);
@@ -612,7 +610,7 @@ suite("TLE", () => {
             });
 
             test("with right square bracket", () => {
-                let pr = parseExpressionWithScope("\"]\"");
+                let pr = parseExpression("\"]\"");
                 assert(pr);
                 assert.equal(undefined, pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -623,10 +621,10 @@ suite("TLE", () => {
             });
 
             test("with function name without parentheses, arguments, or right square bracket", () => {
-                let pr = parseExpressionWithScope("\"[concat\"");
+                let pr = parseExpression("\"[concat\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
-                assert.deepStrictEqual(new TLE.FunctionCallValue(undefined, undefined, TLE.Token.createLiteral(2, "concat"), undefined, [], [], undefined, pr.scope), pr.expression);
+                assert.deepStrictEqual(new TLE.FunctionCallValue(undefined, undefined, TLE.Token.createLiteral(2, "concat"), undefined, [], [], undefined), pr.expression);
                 assert.equal(undefined, pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
                     [
@@ -637,10 +635,10 @@ suite("TLE", () => {
             });
 
             test("with function namespace and period but no function name", () => {
-                let pr = parseExpressionWithScope("\"[concat.\"");
+                let pr = parseExpression("\"[concat.\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
-                assert.deepStrictEqual(new TLE.FunctionCallValue(TLE.Token.createLiteral(2, "concat"), TLE.Token.createPeriod(2 + "concat".length), undefined, undefined, [], [], undefined, pr.scope), pr.expression);
+                assert.deepStrictEqual(new TLE.FunctionCallValue(TLE.Token.createLiteral(2, "concat"), TLE.Token.createPeriod(2 + "concat".length), undefined, undefined, [], [], undefined), pr.expression);
                 assert.equal(undefined, pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
                     [
@@ -652,10 +650,10 @@ suite("TLE", () => {
             });
 
             test("with function name without parentheses or arguments", () => {
-                let pr = parseExpressionWithScope("\"[concat]\"");
+                let pr = parseExpression("\"[concat]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
-                assert.deepStrictEqual(new TLE.FunctionCallValue(undefined, undefined, TLE.Token.createLiteral(2, "concat"), undefined, [], [], undefined, pr.scope), pr.expression);
+                assert.deepStrictEqual(new TLE.FunctionCallValue(undefined, undefined, TLE.Token.createLiteral(2, "concat"), undefined, [], [], undefined), pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(8), pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
                     [new Issue(new Span(2, 6), "Missing function argument list.", tleSyntax)],
@@ -663,7 +661,7 @@ suite("TLE", () => {
             });
 
             test("with function name and left parenthesis without right square bracket", () => {
-                let pr = parseExpressionWithScope("\"[concat (\"");
+                let pr = parseExpression("\"[concat (\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -674,8 +672,7 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(9),
                         [],
                         [],
-                        undefined,
-                        pr.scope),
+                        undefined),
                     pr.expression);
                 assert.equal(undefined, pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -687,7 +684,7 @@ suite("TLE", () => {
             });
 
             test("with function name and left parenthesis", () => {
-                let pr = parseExpressionWithScope("\"[concat (]\"");
+                let pr = parseExpression("\"[concat (]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -698,8 +695,7 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(9),
                         [],
                         [],
-                        undefined,
-                        pr.scope),
+                        undefined),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(10), pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -708,7 +704,7 @@ suite("TLE", () => {
             });
 
             test("with function name and right parenthesis", () => {
-                let pr = parseExpressionWithScope("\"[concat)]\"");
+                let pr = parseExpression("\"[concat)]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -719,8 +715,7 @@ suite("TLE", () => {
                         undefined,
                         [],
                         [],
-                        undefined,
-                        pr.scope),
+                        undefined),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(9), pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -732,7 +727,7 @@ suite("TLE", () => {
             });
 
             test("with function with no arguments", () => {
-                let pr = parseExpressionWithScope("\" [ concat (    )  ]  \"");
+                let pr = parseExpression("\" [ concat (    )  ]  \"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(2), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -743,15 +738,14 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(11),
                         [],
                         [],
-                        TLE.Token.createRightParenthesis(16),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(16)),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(19), pr.rightSquareBracketToken);
                 assert.deepStrictEqual([], pr.errors);
             });
 
             test("with function with one number argument", () => {
-                let pr = parseExpressionWithScope("\"[concat(12)]\"");
+                let pr = parseExpression("\"[concat(12)]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(12), pr.rightSquareBracketToken);
@@ -771,7 +765,7 @@ suite("TLE", () => {
             });
 
             test("with user namespace and function with one number argument", () => {
-                let pr = parseExpressionWithScope("\"[con.at(12)]\"");
+                let pr = parseExpression("\"[con.at(12)]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(12), pr.rightSquareBracketToken);
@@ -791,7 +785,7 @@ suite("TLE", () => {
             });
 
             test("with function with no closing double quote or right square bracket", () => {
-                let pr = parseExpressionWithScope("\"[concat()");
+                let pr = parseExpression("\"[concat()");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -802,8 +796,7 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(8),
                         [],
                         [],
-                        TLE.Token.createRightParenthesis(9),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(9)),
                     pr.expression);
                 assert.deepStrictEqual(undefined, pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -814,7 +807,7 @@ suite("TLE", () => {
             });
 
             test("with function with no closing right square bracket", () => {
-                let pr = parseExpressionWithScope("\"[concat()\"");
+                let pr = parseExpression("\"[concat()\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -825,8 +818,7 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(8),
                         [],
                         [],
-                        TLE.Token.createRightParenthesis(9),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(9)),
                     pr.expression);
                 assert.deepStrictEqual(undefined, pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -837,7 +829,7 @@ suite("TLE", () => {
             });
 
             test("with function with one string argument", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('test')]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('test')]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(16));
@@ -857,7 +849,7 @@ suite("TLE", () => {
             });
 
             test("with function with one string argument with square brackets", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('test[]')]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('test[]')]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(18));
@@ -878,7 +870,7 @@ suite("TLE", () => {
             });
 
             test("with function with one string argument and a comma", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('test',)]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('test',)]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(17));
@@ -909,7 +901,7 @@ suite("TLE", () => {
             });
 
             test("with function with missing first argument and string second argument", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat(,'test')]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat(,'test')]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(17));
@@ -940,7 +932,7 @@ suite("TLE", () => {
             });
 
             test("with function with one missing argument and no right parenthesis", () => {
-                let pr = parseExpressionWithScope("\"[concat('a1',");
+                let pr = parseExpression("\"[concat('a1',");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, undefined);
@@ -972,7 +964,7 @@ suite("TLE", () => {
             });
 
             test("with function with three missing arguments", () => {
-                let pr = parseExpressionWithScope("\"[concat(,,)]\"");
+                let pr = parseExpression("\"[concat(,,)]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -987,8 +979,7 @@ suite("TLE", () => {
                             undefined,
                             undefined
                         ],
-                        TLE.Token.createRightParenthesis(11),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(11)),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(12), pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1001,7 +992,7 @@ suite("TLE", () => {
             });
 
             test("with function with two arguments", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('a', 'b')]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('a', 'b')]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(18));
@@ -1030,7 +1021,7 @@ suite("TLE", () => {
             });
 
             test("with function with three arguments", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('a', 'b', 3)]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('a', 'b', 3)]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(21));
@@ -1064,7 +1055,7 @@ suite("TLE", () => {
             });
 
             test("with function with function argument", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('a', add(5, 7), 3)]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('a', add(5, 7), 3)]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(27));
@@ -1114,7 +1105,7 @@ suite("TLE", () => {
             });
 
             test("with function with single single-quote argument", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat(')]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat(')]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, undefined);
@@ -1140,7 +1131,7 @@ suite("TLE", () => {
             });
 
             test("with function with missing comma between two arguments", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('world'12)]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('world'12)]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(19));
@@ -1165,7 +1156,7 @@ suite("TLE", () => {
             });
 
             test("with function with missing comma between three arguments", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[concat('world'12'again')]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[concat('world'12'again')]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(26));
@@ -1191,7 +1182,7 @@ suite("TLE", () => {
             });
 
             test("with property access", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[resourceGroup().name]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[resourceGroup().name]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(22));
@@ -1213,7 +1204,7 @@ suite("TLE", () => {
             });
 
             test("with property access with missing period", () => {
-                let pr = parseExpressionWithScope("\"[resourceGroup()name]\"");
+                let pr = parseExpression("\"[resourceGroup()name]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1224,15 +1215,14 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(15),
                         [],
                         [],
-                        TLE.Token.createRightParenthesis(16),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(16)),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(21), pr.rightSquareBracketToken);
                 assert.deepStrictEqual([new Issue(new Span(17, 4), "Expected the end of the string.", tleSyntax)], pr.errors);
             });
 
             test("with quoted string instead of literal for property access", () => {
-                const pr = parseExpressionWithScope("\"[resourceGroup().'name']\"");
+                const pr = parseExpression("\"[resourceGroup().'name']\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(24));
@@ -1258,7 +1248,7 @@ suite("TLE", () => {
             });
 
             test("with property access with missing property name", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[resourceGroup().]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[resourceGroup().]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(18));
@@ -1284,7 +1274,7 @@ suite("TLE", () => {
             });
 
             test("with a two-deep property access", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[resourceGroup().name.length]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[resourceGroup().name.length]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(29));
@@ -1311,7 +1301,7 @@ suite("TLE", () => {
             });
 
             test("with array access", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[variables('a')[15]]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[variables('a')[15]]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(20));
@@ -1339,7 +1329,7 @@ suite("TLE", () => {
             });
 
             test("with two array accesses", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[variables('a')[15]['fido']]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[variables('a')[15]['fido']]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(28));
@@ -1377,7 +1367,7 @@ suite("TLE", () => {
             });
 
             test("with array access with function index", () => {
-                const pr: TLE.TleParseResult = parseExpressionWithScope("\"[variables('a')[add(12,3)]]\"");
+                const pr: TLE.TleParseResult = parseExpression("\"[variables('a')[add(12,3)]]\"");
                 assert(pr);
                 assert.deepStrictEqual(pr.leftSquareBracketToken, TLE.Token.createLeftSquareBracket(1));
                 assert.deepStrictEqual(pr.rightSquareBracketToken, TLE.Token.createRightSquareBracket(27));
@@ -1419,7 +1409,7 @@ suite("TLE", () => {
             });
 
             test("with function after string", () => {
-                let pr = parseExpressionWithScope("\"[hello()'world']\"");
+                let pr = parseExpression("\"[hello()'world']\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1430,15 +1420,14 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(7),
                         [],
                         [],
-                        TLE.Token.createRightParenthesis(8),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(8)),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(16), pr.rightSquareBracketToken);
                 assert.deepStrictEqual([new Issue(new Span(9, 7), "Expected the end of the string.", tleSyntax)], pr.errors);
             });
 
             test("with function after string", () => {
-                let pr = parseExpressionWithScope("\"[hello'world'()]\"");
+                let pr = parseExpression("\"[hello'world'()]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1449,15 +1438,14 @@ suite("TLE", () => {
                         TLE.Token.createLeftParenthesis(14),
                         [],
                         [],
-                        TLE.Token.createRightParenthesis(15),
-                        pr.scope),
+                        TLE.Token.createRightParenthesis(15)),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(16), pr.rightSquareBracketToken);
                 assert.deepStrictEqual([new Issue(new Span(7, 7), "Expected the end of the string.", tleSyntax)], pr.errors);
             });
 
             test("with string followed by literal", () => {
-                let pr = parseExpressionWithScope("\"['world'hello]\"");
+                let pr = parseExpression("\"['world'hello]\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1468,8 +1456,7 @@ suite("TLE", () => {
                         undefined,
                         [],
                         [],
-                        undefined,
-                        pr.scope),
+                        undefined),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(14), pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1481,7 +1468,7 @@ suite("TLE", () => {
             });
 
             test("with literal followed by string", () => {
-                let pr = parseExpressionWithScope("\"[hello'world']\"");
+                let pr = parseExpression("\"[hello'world']\"");
                 assert(pr);
                 assert.deepStrictEqual(TLE.Token.createLeftSquareBracket(1), pr.leftSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1492,8 +1479,7 @@ suite("TLE", () => {
                         undefined,
                         [],
                         [],
-                        undefined,
-                        pr.scope),
+                        undefined),
                     pr.expression);
                 assert.deepStrictEqual(TLE.Token.createRightSquareBracket(14), pr.rightSquareBracketToken);
                 assert.deepStrictEqual(
@@ -1505,7 +1491,7 @@ suite("TLE", () => {
             });
 
             test(`with "[concat(parameters('_artifactsLocation'), '/', '/scripts/azuremysql.sh', parameters('_artifactsLocationSasToken'))], )]"`, () => {
-                const pr = parseExpressionWithScope(`"[concat(parameters('_artifactsLocation'), '/', '/scripts/azuremysql.sh', parameters('_artifactsLocationSasToken'))], )]"`);
+                const pr = parseExpression(`"[concat(parameters('_artifactsLocation'), '/', '/scripts/azuremysql.sh', parameters('_artifactsLocationSasToken'))], )]"`);
                 assert.deepStrictEqual(
                     pr.errors,
                     [
@@ -1975,15 +1961,15 @@ suite("TLE", () => {
             const functionMetadata: FunctionsMetadata = new FunctionsMetadata([new BuiltinFunctionMetadata("CONCAT", "", "", 1, 2, [], undefined)]);
 
             test("with recognized function", () => {
-                const tleParseResult = parseExpressionWithScope("'[concat()]'");
-                const visitor = UnrecognizedFunctionVisitor.visit(tleParseResult.scope, tleParseResult.expression, functionMetadata);
+                const tleParseResult = parseExpression("'[concat()]'");
+                const visitor = UnrecognizedFunctionVisitor.visit(emptyScope, tleParseResult.expression, functionMetadata);
                 assert(visitor);
                 assert.deepStrictEqual([], visitor.errors);
             });
 
             test("with unrecognized function", () => {
-                const tleParseResult = parseExpressionWithScope("'[concatenate()]'");
-                const visitor = UnrecognizedFunctionVisitor.visit(tleParseResult.scope, tleParseResult.expression, functionMetadata);
+                const tleParseResult = parseExpression("'[concatenate()]'");
+                const visitor = UnrecognizedFunctionVisitor.visit(emptyScope, tleParseResult.expression, functionMetadata);
                 assert(visitor);
                 assert.deepStrictEqual(
                     [
@@ -2000,48 +1986,48 @@ suite("TLE", () => {
             const functions = AzureRMAssets.getFunctionsMetadata();
 
             test("with undefined value", () => {
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(undefined, functions);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, undefined, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with undefined value", () => {
                 // tslint:disable-next-line:no-any
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(<any>undefined, functions);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, <any>undefined, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with number value", () => {
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(new TLE.NumberValue(TLE.Token.createNumber(17, "3")), functions);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, new TLE.NumberValue(TLE.Token.createNumber(17, "3")), functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with concat() with zero arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[concat()]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[concat()]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with concat() with one argument", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[concat(12)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[concat(12)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with concat() with two arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[concat(12, 'test')]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[concat(12, 'test')]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with add() with zero arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[add()]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[add()]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2049,8 +2035,8 @@ suite("TLE", () => {
             });
 
             test("with add() with one argument", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[add(5)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[add(5)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2058,15 +2044,15 @@ suite("TLE", () => {
             });
 
             test("with add() with two arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[add(5, 6)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[add(5, 6)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with add() with three arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[add(5, 6, 7)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[add(5, 6, 7)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2074,8 +2060,8 @@ suite("TLE", () => {
             });
 
             test("with add() with three arguments and different casing", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[Add(5, 6, 7)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[Add(5, 6, 7)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2083,8 +2069,8 @@ suite("TLE", () => {
             });
 
             test("with resourceId() with zero arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[resourceId()]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[resourceId()]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2093,8 +2079,8 @@ suite("TLE", () => {
             });
 
             test("with resourceId() with one argument", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[resourceId(5)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[resourceId(5)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2103,22 +2089,22 @@ suite("TLE", () => {
             });
 
             test("with resourceId() with two arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[resourceId(5, 6)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[resourceId(5, 6)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with resourceId() with three arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[resourceId(5, 6, 7)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[resourceId(5, 6, 7)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with substring() with zero arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[substring()]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[substring()]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2126,29 +2112,29 @@ suite("TLE", () => {
             });
 
             test("with substring() with one argument", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[substring('abc')]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[substring('abc')]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with substring() with two arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[substring('abc', 1)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[substring('abc', 1)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with substring() with three arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[substring('abc', 1, 1)]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[substring('abc', 1, 1)]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.errors, []);
             });
 
             test("with substring() with four arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[substring('abc', 1, 1, 'blah')]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[substring('abc', 1, 1, 'blah')]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2156,8 +2142,8 @@ suite("TLE", () => {
             });
 
             test("user function with name matching a built-in, with zero arguments", () => {
-                const concat: TLE.Value = nonNullValue(parseExpressionWithScope(`"[Contoso.resourceId()]"`).expression);
-                const visitor = IncorrectFunctionArgumentCountVisitor.visit(concat, functions);
+                const concat: TLE.Value = nonNullValue(parseExpression(`"[Contoso.resourceId()]"`).expression);
+                const visitor = IncorrectFunctionArgumentCountVisitor.visit(emptyScope, concat, functions);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.errors,
@@ -2224,7 +2210,7 @@ suite("TLE", () => {
                 const dt = await parseTemplate(template);
                 const param = dt.topLevelScope.getParameterDefinition("pName")!;
                 assert(param);
-                const visitor = FindReferencesVisitor.visit(dt, undefined, param, metadata);
+                const visitor = FindReferencesVisitor.visit(dt, dt.topLevelScope, undefined, param, metadata);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.references, new ReferenceList(DefinitionKind.Parameter));
             });
@@ -2234,7 +2220,7 @@ suite("TLE", () => {
                 const param = dt.topLevelScope.getParameterDefinition("pName")!;
                 assert(param);
                 // tslint:disable-next-line:no-any
-                const visitor = FindReferencesVisitor.visit(dt, <any>undefined, param, metadata);
+                const visitor = FindReferencesVisitor.visit(dt, dt.topLevelScope, <any>undefined, param, metadata);
                 assert(visitor);
                 assert.deepStrictEqual(visitor.references, new ReferenceList(DefinitionKind.Parameter));
             });
@@ -2243,8 +2229,8 @@ suite("TLE", () => {
                 const dt = await parseTemplate(template);
                 const param = dt.topLevelScope.getParameterDefinition("pName")!;
                 assert(param);
-                const pr: TLE.TleParseResult = parseExpressionWithScope(`"[parameters('pName')]"`, dt.topLevelScope);
-                const visitor = FindReferencesVisitor.visit(dt, pr.expression, param, metadata);
+                const pr: TLE.TleParseResult = parseExpression(`"[parameters('pName')]"`);
+                const visitor = FindReferencesVisitor.visit(dt, dt.topLevelScope, pr.expression, param, metadata);
                 assert(visitor);
                 assert.deepStrictEqual(
                     visitor.references,

--- a/test/TemplatePositionContext.test.ts
+++ b/test/TemplatePositionContext.test.ts
@@ -276,7 +276,8 @@ suite("TemplatePositionContext", () => {
         test("with characterIndex at the start of a non-TLE QuotedString", () => {
             let dt = new DeploymentTemplateDoc("{ 'a': 'A', 'b': \"[concat('B')]\" }", fakeId);
             let pc = dt.getContextFromDocumentCharacterIndex(2, undefined);
-            assert.deepStrictEqual(TLE.Parser.parse("'a'", dt.topLevelScope), pc.tleInfo!.tleParseResult);
+            const parseResult = TLE.Parser.parse("'a'");
+            assert.deepStrictEqual(parseResult, pc.tleInfo!.tleParseResult);
         });
 
         test("with characterIndex at the start of a closed TLE QuotedString", () => {

--- a/test/templates/ResourceInfo.test.ts
+++ b/test/templates/ResourceInfo.test.ts
@@ -6,7 +6,7 @@
 // tslint:disable: max-func-body-length object-literal-key-quotes
 
 import * as assert from "assert";
-import { getResourcesInfo, IResourceInfo, ResourceInfo } from "../../extension.bundle";
+import { getResourcesInfo, ResourceInfo } from "../../extension.bundle";
 import { IPartialDeploymentTemplate } from "../support/diagnostics";
 import { parseTemplate } from "../support/parseTemplate";
 
@@ -94,7 +94,7 @@ suite("ResourceInfo", () => {
     suite("getResourceIdExpression", () => {
         function createResourceIdTest(
             testName: string,
-            resource: IResourceInfo,
+            resource: ResourceInfo,
             expected: string | undefined
         ): void {
             testName = testName + JSON.stringify(`${resource.getFullTypeExpression()}: ${resource.getFullNameExpression()}`);


### PR DESCRIPTION
This should help break up some circular dependencies I'm running into in some new code.

TleParseResult had a pointer to the relevant TemplateScope.  Now that reference is kept in the external dictionary that associates TleParseResults with the the JSON strings that were parsed.