### PR TITLE
Change tree from <string> to <IElementInfo> directly, also null->undefined

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -92,8 +92,8 @@ export { UnrecognizedFunctionVisitor } from "./src/visitors/UnrecognizedFunction
 export { IGotoParameterValueArgs } from "./src/vscodeIntegration/commandArguments";
 export { IConfiguration } from "./src/vscodeIntegration/Configuration";
 export { HoverInfo } from "./src/vscodeIntegration/Hover";
-export { JsonOutlineProvider, shortenTreeLabel } from "./src/vscodeIntegration/Treeview";
-export { getVSCodePositionFromPosition, getVSCodeRangeFromSpan } from "./src/vscodeIntegration/vscodePosition";
+export { IElementInfo, JsonOutlineProvider, shortenTreeLabel } from "./src/vscodeIntegration/Treeview";
+export * from "./src/vscodeIntegration/vscodePosition";
 export { Completion };
 export { Json };
 export { basic };

--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -160,7 +160,9 @@ export class AzureRMTools {
         registerCommand("azurerm-vscode-tools.completion-activated", (actionContext: IActionContext, args: object) => {
             onCompletionActivated(actionContext, <{ [key: string]: string }>args);
         });
-        registerCommand("azurerm-vscode-tools.treeview.goto", (_actionContext: IActionContext, range: vscode.Range) => jsonOutline.goToDefinition(range));
+        registerCommand("azurerm-vscode-tools.treeview.goto", (_actionContext: IActionContext, range: vscode.Range) => {
+            jsonOutline.revealRangeInEditor(range);
+        });
         registerCommand("azurerm-vscode-tools.sortTemplate", async (_context: IActionContext, uri?: vscode.Uri, editor?: vscode.TextEditor) => {
             editor = editor || vscode.window.activeTextEditor;
             uri = uri || vscode.window.activeTextEditor?.document.uri;

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -11,6 +11,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { parseError } from "vscode-azureextensionui";
 import { ext, JsonOutlineProvider, shortenTreeLabel } from "../extension.bundle";
+import { IElementInfo } from "../src/vscodeIntegration/Treeview";
 import { getTempFilePath } from "./support/getTempFilePath";
 
 suite("TreeView", async (): Promise<void> => {
@@ -125,7 +126,7 @@ suite("TreeView", async (): Promise<void> => {
             await testTree(template, expected, ["icon"]);
         }
 
-        function getTree(element?: string): ITestTreeItem[] {
+        function getTree(element?: IElementInfo): ITestTreeItem[] {
             let children = provider.getChildren(element);
             let tree = children.map(child => {
                 let treeItem = provider.getTreeItem(child);

--- a/test/Treeview.test.ts
+++ b/test/Treeview.test.ts
@@ -10,8 +10,7 @@ import * as fse from 'fs-extra';
 import * as path from "path";
 import * as vscode from "vscode";
 import { parseError } from "vscode-azureextensionui";
-import { ext, JsonOutlineProvider, shortenTreeLabel } from "../extension.bundle";
-import { IElementInfo } from "../src/vscodeIntegration/Treeview";
+import { ext, IElementInfo, JsonOutlineProvider, shortenTreeLabel } from "../extension.bundle";
 import { getTempFilePath } from "./support/getTempFilePath";
 
 suite("TreeView", async (): Promise<void> => {


### PR DESCRIPTION
No functionality changes.  Previously the treeview provider worked on IElementInfo's that were serialized to/from string.  That is not necessary (maybe it was previously).