### PR TITLE
1008 Only allow dependsOn completions at the start of a string

### DIFF
--- a/src/documents/positionContexts/TemplatePositionContext.ts
+++ b/src/documents/positionContexts/TemplatePositionContext.ts
@@ -36,6 +36,9 @@ import { ICompletionItemsResult, IReferenceSite, PositionContext, ReferenceSiteK
 class TleInfo implements ITleInfo {
     public constructor(
         public readonly tleParseResult: TLE.TleParseResult,
+        /**
+         * Index of the cursor from the start of the TLE string
+         */
         public readonly tleCharacterIndex: number,
         public readonly tleValue: TLE.Value | undefined,
         public readonly scope: TemplateScope

--- a/src/documents/templates/getDependsOnCompletions.ts
+++ b/src/documents/templates/getDependsOnCompletions.ts
@@ -28,6 +28,12 @@ export function getDependsOnCompletions(
         span = pc.emptySpanAtDocumentCharacterIndex;
     }
 
+    // Allow suggest dependsOn completions when at the very beginning of the string or outside a string.  Elsewhere in
+    //   the expression they will just add a bunch of completions that are confusing for the context
+    if (pc.tleInfo && pc.tleInfo.tleCharacterIndex > 1) {
+        return [];
+    }
+
     const scope = pc.getScope();
     const infos = getResourcesInfo({ scope, recognizeDecoupledChildren: true });
     if (infos.length === 0) {

--- a/test/dependsOn.completions.test.ts
+++ b/test/dependsOn.completions.test.ts
@@ -675,7 +675,7 @@ from resource \`name1a\` of type \`def\``
                     resources: [
                         {
                             dependsOn: [
-                                "<!replaceStart!>name<!cursor!>2a"
+                                "<!replaceStart!><!cursor!>name2a"
                             ]
                         },
                         {
@@ -694,6 +694,26 @@ from resource \`name1a\` of type \`def\``
             }
         );
 
+        createDependsOnCompletionsTest(
+            "no dependsOn completions except at the start of the string (#1008)",
+            {
+                template: {
+                    resources: [
+                        {
+                            dependsOn: [
+                                "<!replaceStart!>name<!cursor!>2a"
+                            ]
+                        },
+                        {
+                            type: "microsoft.abc/def",
+                            name: "name1a"
+                        }
+                    ]
+                },
+                expected: [
+                ]
+            }
+        );
     });
 
     createDependsOnCompletionsTest(
@@ -703,7 +723,7 @@ from resource \`name1a\` of type \`def\``
                 resources: [
                     {
                         DEPENDSON: [
-                            "<!replaceStart!>name<!cursor!>2a"
+                            "<!replaceStart!><!cursor!>name2a"
                         ]
                     },
                     {

--- a/test/resourceId.completions.test.ts
+++ b/test/resourceId.completions.test.ts
@@ -1100,10 +1100,10 @@ suite("ResourceId completions", () => {
             },
             'resourceId(!)',
             [
-                "LOOP ${vmName}vmcopy",
+                "Loop ${vmName}vmcopy",
                 "'Microsoft.Compute/virtualMachines'",
                 "'Microsoft.Compute/virtualMachines/extensions'",
-                "parent ([concat(${vmName}, copyIndex(1))])",
+                "Parent ([concat(${vmName}, copyIndex(1))])",
             ]
         );
     });

--- a/test/resourceId.completions.test.ts
+++ b/test/resourceId.completions.test.ts
@@ -1100,10 +1100,8 @@ suite("ResourceId completions", () => {
             },
             'resourceId(!)',
             [
-                "Loop ${vmName}vmcopy",
                 "'Microsoft.Compute/virtualMachines'",
                 "'Microsoft.Compute/virtualMachines/extensions'",
-                "Parent ([concat(${vmName}, copyIndex(1))])",
             ]
         );
     });


### PR DESCRIPTION
Fixes #1008 

Before with cursor in the middle of "concat":
![image](https://user-images.githubusercontent.com/6913354/94979229-71947800-04d6-11eb-99dd-f2d37d1ef8cb.png)

After:
![image](https://user-images.githubusercontent.com/6913354/94979218-5fb2d500-04d6-11eb-9590-16d2b874915a.png)

