### PR TITLE
Corrects minor typo for `deprecrated`

### DIFF
--- a/src/AzureRMTools.ts
+++ b/src/AzureRMTools.ts
@@ -796,7 +796,7 @@ export class AzureRMTools {
                 const neverForThisFile: vscode.MessageItem = { title: "Never for this file" };
 
                 const response = await ext.ui.showWarningMessage(
-                    `Warning: You are using a deprecrated schema version that is no longer maintained.  Would you like us to update "${path.basename(document.uri.path)}" to use the newest schema?`,
+                    `Warning: You are using a deprecated schema version that is no longer maintained.  Would you like us to update "${path.basename(document.uri.path)}" to use the newest schema?`,
                     {
                         learnMoreLink: "https://aka.ms/vscode-azurearmtools-updateschema"
                     },


### PR DESCRIPTION
`deprecrated` --> `deprecated`


![image](https://user-images.githubusercontent.com/2286713/101281529-5b9d7f00-37c7-11eb-89c9-b01b81ee5f2e.png)