### PR TITLE
Add sleutho.tmcolor to vscode recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ms-vscode.vscode-typescript-tslint-plugin"
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "sleutho.tmcolor"
     ]
 }


### PR DESCRIPTION
As part of reviewing the arm-colors.tmcolor file, I added this recommended extension.