### PR TITLE
Disable support for virtual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
         "Formatters",
         "Snippets"
     ],
+    "capabilities": {
+        "virtualWorkspaces": {
+            "supported": false
+        }
+    },
     "keywords": [
         "Azure Template",
         "ARM",


### PR DESCRIPTION
Fixes #1647 

See https://github.com/Azure/bicep/issues/11467 for details.  This extension uses valid but unusual URIs that System.Uri doesn't support.  Current solution is to disable the extension in this scenario.