### PR TITLE
Update required vscode version to 1.75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "@types/rimraf": "2.0.2",
                 "@types/shelljs": "0.8.15",
                 "@types/vinyl": "^2.0.12",
-                "@types/vscode": "^1.62.0",
+                "@types/vscode": "^1.75.0",
                 "@types/webpack": "^5.28.5",
                 "@vscode/test-cli": "0.0.10",
                 "@vscode/test-electron": "^2.4.1",
@@ -53,7 +53,7 @@
             },
             "engines": {
                 "$comment": "Must match version of @types/vscode in devDepndencies",
-                "vscode": "^1.62.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@azure/ms-rest-azure-env": {

--- a/package.json
+++ b/package.json
@@ -43,38 +43,14 @@
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "engines": {
         "$comment": "Must match version of @types/vscode in devDepndencies",
-        "vscode": "^1.62.0"
+        "vscode": "^1.75.0"
     },
     "preview": true,
     "activationEvents": [
-        "onLanguage:arm-template",
         "onLanguage:json",
         "onLanguage:jsonc",
-        "onCommand:azurerm-vscode-tools.sortTemplate",
-        "onCommand:azurerm-vscode-tools.sortFunctions",
-        "onCommand:azurerm-vscode-tools.sortOutputs",
-        "onCommand:azurerm-vscode-tools.sortParameters",
-        "onCommand:azurerm-vscode-tools.sortResources",
-        "onCommand:azurerm-vscode-tools.sortVariables",
-        "onCommand:azurerm-vscode-tools.selectParameterFile",
-        "onCommand:azurerm-vscode-tools.openParameterFile",
-        "onCommand:azurerm-vscode-tools.openTemplateFile",
-        "onCommand:azurerm-vscode-tools.codeLens.openLinkedTemplateFile",
-        "onCommand:azurerm-vscode-tools.codeLens.reloadLinkedTemplateFile",
-        "onCommand:azurerm-vscode-tools.codeLens.gotoParameterValue",
-        "onCommand:azurerm-vscode-tools.codeAction.addAllMissingParameters",
-        "onCommand:azurerm-vscode-tools.codeAction.addMissingRequiredParameters",
         "onCommand:azurerm-vscode-tools.codeAction.extractParameter",
-        "onCommand:azurerm-vscode-tools.codeAction.extractVariable",
-        "onCommand:azurerm-vscode-tools.insertItem",
-        "onCommand:azurerm-vscode-tools.insertParameter",
-        "onCommand:azurerm-vscode-tools.insertVariable",
-        "onCommand:azurerm-vscode-tools.insertOutput",
-        "onCommand:azurerm-vscode-tools.insertFunction",
-        "onCommand:azurerm-vscode-tools.insertResource",
-        "onCommand:azurerm-vscode-tools.developer.resetGlobalState",
-        "onCommand:azurerm-vscode-tools.developer.showInsertionContext",
-        "onCommand:azurerm-vscode-tools.developer.showAvailableResourceTypesAndVersions"
+        "onCommand:azurerm-vscode-tools.codeAction.extractVariable"
     ],
     "contributes": {
         "grammars": [
@@ -645,7 +621,7 @@
         "@types/recursive-readdir": "^2.2.1",
         "@types/rimraf": "2.0.2",
         "@types/shelljs": "0.8.15",
-        "@types/vscode": "^1.62.0",
+        "@types/vscode": "^1.75.0",
         "@types/vinyl": "^2.0.12",
         "@types/webpack": "^5.28.5",
         "@vscode/test-cli": "0.0.10",


### PR DESCRIPTION
Built on top of https://github.com/microsoft/vscode-azurearmtools/pull/1786

VSCode is up to version 1.95, and updating allows us to get rid of many activationEvents that are now automatic:

![image](https://github.com/user-attachments/assets/23e31ad3-e74e-49fc-a27f-8f7dce0bdc02)
